### PR TITLE
feat: 회원가입 API 구현을 위한 User 엔티티 및 Role 열거형 추가

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
@@ -1,0 +1,6 @@
+package faithcoderlab.newdpraise.domain.user;
+
+public enum Role {
+  // 역할 필요
+  // 관리자, 밴드 리더, 팀원, 일반 회원도 필요할까?
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
@@ -1,6 +1,7 @@
 package faithcoderlab.newdpraise.domain.user;
 
 public enum Role {
-  // 역할 필요
-  // 관리자, 밴드 리더, 팀원, 일반 회원도 필요할까?
+  ADMIN, // 관리자
+  BAND_LEADER, // 밴드 리더
+  TEAM_MEMBER // 팀원
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/User.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/User.java
@@ -1,0 +1,106 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Entity
+@Table(name = "users")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User implements UserDetails {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(nullable = false)
+  private String name;
+
+  private String profileImage;
+
+  @Column(name = "instrument")
+  private String instrument;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+  @Column(nullable = false)
+  private boolean enabled;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+    updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    return authorities;
+  }
+
+  @Override
+  public String getUsername() {
+    return email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 사용자 계정 관리를 위한 도메인 엔티티가 정의되지 않은 상태
- 사용자 권한 및 역할 체계가 구현되지 않은 상태

**TO-BE**
- 회원가입 API 개발을 위한 User 엔티티 클래스 구현
  - Spring Security UserDetails 인터페이스 구현으로 인증 시스템과 통합
  - 사용자 기본 정보(이메일, 비밀번호, 이름, 프로필, 담당 악기 등) 포함
- 사용자 권한 관리를 위한 Role 열거형 클래스 추가
  - ADMIN, BAND_LEADER, TEAM_MEMBER 역할 정의
  - Spring Security 권한 체계와 연동 준비

### 테스트
이번 PR은 도메인 엔티티 클래스만 ERD에 따라 추가한 것으로, 실제 API 구현 및 테스트는 후속 PR에서 진행할 예정입니다.