### PR TITLE
feat: 회원가입 API 구현을 위한 컨트롤러, 서비스, DTO 구현

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package faithcoderlab.newdpraise.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableJpaAuditing
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        )
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/users/signup").permitAll()
+            .anyRequest().authenticated()
+        );
+
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/Role.java
@@ -3,5 +3,6 @@ package faithcoderlab.newdpraise.domain.user;
 public enum Role {
   ADMIN, // 관리자
   BAND_LEADER, // 밴드 리더
-  TEAM_MEMBER // 팀원
+  TEAM_MEMBER, // 팀원
+  USER // 일반 회원
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
@@ -1,0 +1,24 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+    SignupResponse response = userService.signup(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
@@ -1,6 +1,7 @@
 package faithcoderlab.newdpraise.domain.user;
 
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
+import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
@@ -1,5 +1,6 @@
 package faithcoderlab.newdpraise.domain.user;
 
+import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserRepository.java
@@ -1,0 +1,13 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package faithcoderlab.newdpraise.domain.user;
 
+import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
@@ -1,0 +1,35 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional
+  public SignupResponse signup(SignupRequest request) {
+    if (userRepository.existsByEmail(request.getEmail())) {
+      throw new ResourceAlreadyExistsException("이미 사용 중인 이메일입니다.");
+    }
+
+    User user = User.builder()
+        .email(request.getEmail())
+        .password(passwordEncoder.encode(request.getPassword()))
+        .name(request.getName())
+        .instrument(request.getInstrument())
+        .profileImage(request.getProfileImage())
+        .role(Role.USER)
+        .enabled(true)
+        .build();
+
+    User savedUser = userRepository.save(user);
+
+    return SignupResponse.fromUser(savedUser);
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
@@ -1,6 +1,7 @@
 package faithcoderlab.newdpraise.domain.user;
 
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
+import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserService.java
@@ -2,6 +2,7 @@ package faithcoderlab.newdpraise.domain.user;
 
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
+import faithcoderlab.newdpraise.global.exception.ResourceAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupRequest.java
@@ -1,0 +1,34 @@
+package faithcoderlab.newdpraise.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+
+  @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+  @Email(message = "유효한 이메일 형식이 아닙니다.")
+  private String email;
+
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+  @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+  @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*).*$",
+      message = "비밀번호는 숫자, 영문자, 특수문자를 포함해야 합니다.")
+  private String password;
+
+  @NotBlank(message = "이름은 필수 입력 항목입니다.")
+  private String name;
+
+  private String instrument;
+
+  private String profileImage;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupResponse.java
@@ -1,0 +1,35 @@
+package faithcoderlab.newdpraise.domain.user.dto;
+
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupResponse {
+  private Long id;
+  private String email;
+  private String name;
+  private String instrument;
+  private String profileImage;
+  private Role role;
+  private LocalDateTime createdAt;
+
+  public static SignupResponse fromUser(User user) {
+    return SignupResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .instrument(user.getInstrument())
+        .profileImage(user.getProfileImage())
+        .role(user.getRole())
+        .createdAt(user.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package faithcoderlab.newdpraise.global.exception;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(ResourceAlreadyExistsException.class)
+  public ResponseEntity<ErrorResponse> handleResourceAlreadyExistsException(
+      ResourceAlreadyExistsException ex) {
+    ErrorResponse errorResponse = new ErrorResponse(
+        HttpStatus.CONFLICT.value(),
+        ex.getMessage(),
+        LocalDateTime.now()
+    );
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+  }
+
+  @Getter
+  public static class ErrorResponse {
+    private final int status;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public ErrorResponse(int status, String message, LocalDateTime timestamp) {
+      this.status = status;
+      this.message = message;
+      this.timestamp = timestamp;
+    }
+
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/global/exception/ResourceAlreadyExistsException.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/exception/ResourceAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package faithcoderlab.newdpraise.global.exception;
+
+public class ResourceAlreadyExistsException extends RuntimeException {
+
+  public ResourceAlreadyExistsException(String message) {
+    super(message);
+  }
+
+  public ResourceAlreadyExistsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- User 엔티티와 Role 열거형은 구현되었으나 실제 API 동작을 위한 컴포넌트 부재
- 회원가입 기능 구현을 위한 컨트롤러, 서비스, 데이터 접근 계층이 없음
- 클라이언트와의 데이터 교환을 위한 DTO 객체 미구현

**TO-BE**
- 회원가입 API 엔드포인트 구현 (/api/users/signup)
  - UserController: 회원가입 요청 처리 및 응답 반환
  - UserService: 회원가입 비즈니스 로직 처리 (중복 확인, 비밀번호 암호화)
  - UserRepository: 사용자 데이터 저장 및 조회 기능
  - SignupRequest: 회원가입 요청 DTO
  - SignupResponse: 회원가입 응답 DTO

### 테스트
- 예외 처리 클래스 구현 후 테스트 예정
- 현재 비즈니스 로직과 API 엔드포인트의 기본 구조만 구현한 상태