### PR TITLE
feat: 회원가입 API 문서화 및 테스트 코드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ out/
 application-local.yml
 application-dev.yml
 application-prod.yml
+application-test.yml

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package faithcoderlab.newdpraise.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -34,6 +35,7 @@ public class SecurityConfig {
   }
 
   @Bean
+  @Profile("!test")
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }

--- a/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
@@ -25,6 +25,8 @@ public class SecurityConfig {
         )
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/users/signup").permitAll()
+            .requestMatchers("/swagger-ui/**").permitAll()
+            .requestMatchers("/v3/api-docs/**").permitAll()
             .anyRequest().authenticated()
         );
 

--- a/src/main/java/faithcoderlab/newdpraise/config/SwaggerConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package faithcoderlab.newdpraise.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .title("NewDpraise API")
+        .version("1.0.0")
+        .description("공연 콘티 관련 서비스 API 문서");
+
+    String securitySchemeName = "bearerAuth";
+    SecurityScheme securityScheme = new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("JWT")
+        .in(SecurityScheme.In.HEADER)
+        .name("Authorization");
+
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList(securitySchemeName);
+
+    return new OpenAPI()
+        .info(info)
+        .components(new Components().addSecuritySchemes(securitySchemeName, securityScheme))
+        .addSecurityItem(securityRequirement);
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/config/TestConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/TestConfig.java
@@ -1,0 +1,15 @@
+package faithcoderlab.newdpraise.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@TestConfiguration
+public class TestConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/UserController.java
@@ -2,6 +2,12 @@ package faithcoderlab.newdpraise.domain.user;
 
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,10 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 관련 API")
 public class UserController {
 
   private final UserService userService;
 
+  @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "회원가입 성공",
+          content = @Content(schema = @Schema(implementation = SignupResponse.class))),
+      @ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일"),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터")
+  })
   @PostMapping("/signup")
   public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
     SignupResponse response = userService.signup(request);

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/dto/SignupRequest.java
@@ -21,7 +21,7 @@ public class SignupRequest {
 
   @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
   @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-  @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*).*$",
+  @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()]).+$",
       message = "비밀번호는 숫자, 영문자, 특수문자를 포함해야 합니다.")
   private String password;
 

--- a/src/test/java/faithcoderlab/newdpraise/config/TestConfig.java
+++ b/src/test/java/faithcoderlab/newdpraise/config/TestConfig.java
@@ -2,6 +2,7 @@ package faithcoderlab.newdpraise.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class TestConfig {
 
   @Bean
+  @Primary
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
@@ -1,0 +1,93 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+@Transactional
+public class UserApiTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @BeforeEach
+  void setUp() {
+    userRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("회원가입 API 통합 테스트 - 성공")
+  void signupApiSuccess() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("suming@example.com")
+        .password("Password123!")
+        .name("수밍")
+        .instrument("피아노")
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.email").value("suming@example.com"))
+        .andExpect(jsonPath("$.name").value("수밍"))
+        .andExpect(jsonPath("$.instrument").value("피아노"))
+        .andExpect(jsonPath("$.role").value("USER"));
+  }
+
+  @Test
+  @DisplayName("회원가입 API 통합 테스트 - 중복 이메일 실패")
+  void signupApiDuplicateEmailFail() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("duplicate@example.com")
+        .name("테스트유저")
+        .instrument("베이스")
+        .build();
+
+    // 첫번째 요청은 성공
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated());
+
+    // when & then
+    // 두번째 요청은 실패
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다."));
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Import(TestConfig.class)
+@Import(faithcoderlab.newdpraise.config.TestConfig.class)
 @ActiveProfiles("test")
 @Transactional
 public class UserApiTest {
@@ -71,6 +71,7 @@ public class UserApiTest {
     // given
     SignupRequest request = SignupRequest.builder()
         .email("duplicate@example.com")
+        .password("Password123!")
         .name("테스트유저")
         .instrument("베이스")
         .build();

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
@@ -1,0 +1,128 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
+import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private UserService userService;
+
+  @Test
+  @DisplayName("회원가입 성공 테스트")
+  void signupSuccess() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("suming@example.com")
+        .password("Password123!")
+        .name("수밍")
+        .instrument("피아노")
+        .build();
+
+    SignupResponse response = SignupResponse.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .instrument("피아노")
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    when(userService.signup(any(SignupRequest.class))).thenReturn(response);
+
+    // when & then
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.email").value("suming@example.com"))
+        .andExpect(jsonPath("$.name").value("수밍"))
+        .andExpect(jsonPath("$.instrument").value("피아노"))
+        .andExpect(jsonPath("$.role").value("USER"));
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 유효하지 않은 이메일")
+  void SignupRailWithInvalidEmail() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("invalid-email") // 이메일 형식 X
+        .password("Password123!")
+        .name("테스트유저")
+        .instrument("드럼")
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 비밀번호 유효성 검사")
+  void SignupRailWithInvalidPassword() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("test@example.com")
+        .password("short") // 8자 미만
+        .name("테스트유저")
+        .instrument("기타")
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 이름 누락")
+  void signupFailWithMissingName() throws Exception {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("suming@example.com")
+        .password("Password123!")
+        .name("") // 이름 누락
+        .instrument("베이스")
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import faithcoderlab.newdpraise.config.TestConfig;
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
 import java.time.LocalDateTime;
@@ -19,15 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Import(TestConfig.class)
 class UserControllerTest {
 
   @Autowired

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
 import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
 import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
 import java.time.LocalDateTime;
@@ -18,11 +19,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestConfig.class)
 class UserControllerTest {
 
   @Autowired

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserServiceTest.java
@@ -1,0 +1,97 @@
+package faithcoderlab.newdpraise.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import faithcoderlab.newdpraise.domain.user.dto.SignupRequest;
+import faithcoderlab.newdpraise.domain.user.dto.SignupResponse;
+import faithcoderlab.newdpraise.global.exception.ResourceAlreadyExistsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @InjectMocks
+  private UserService userService;
+
+  @Test
+  @DisplayName("회원가입 성공")
+  void signupSuccess() {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("suming@example.com")
+        .password("Password123!")
+        .name("수밍")
+        .instrument("피아노")
+        .build();
+
+    when(userRepository.existsByEmail(anyString())).thenReturn(false);
+    when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+
+    User savedUser = User.builder()
+        .id(1L)
+        .email(request.getEmail())
+        .password("encodedPassword")
+        .name(request.getName())
+        .instrument(request.getInstrument())
+        .role(Role.USER)
+        .enabled(true)
+        .build();
+
+    when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+    // when
+    SignupResponse response = userService.signup(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getEmail()).isEqualTo(savedUser.getEmail());
+    assertThat(response.getName()).isEqualTo(savedUser.getName());
+    assertThat(response.getInstrument()).isEqualTo(savedUser.getInstrument());
+    assertThat(response.getRole()).isEqualTo(Role.USER);
+
+    verify(userRepository).existsByEmail(request.getEmail());
+    verify(passwordEncoder).encode(request.getPassword());
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  @DisplayName("회원가입 실패 - 중복 이메일")
+  void signupFailWithDuplicateEmail() {
+    // given
+    SignupRequest request = SignupRequest.builder()
+        .email("existing@example.com")
+        .password("Password123!")
+        .name("테스트유저")
+        .instrument("기타")
+        .build();
+
+    when(userRepository.existsByEmail(anyString())).thenReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> userService.signup(request))
+        .isInstanceOf(ResourceAlreadyExistsException.class)
+        .hasMessage("이미 사용 중인 이메일입니다.");
+
+    verify(userRepository).existsByEmail(request.getEmail());
+    verify(userRepository, never()).save(any(User.class));
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,12 @@ spring:
         format_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+logging:
+  level:
+    org.springframework: DEBUG
+    org.hibernate: DEBUG
+    faithcoderlab.newdpraise: DEBUG
+
 
 # Youtube API 설정
 youtube:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+
+# Youtube API 설정
+youtube:
+  api:
+    key: test-api-key
+
+# 업로드 경로 설정
+file:
+  upload-dir: ./test-uploads
+  max-size: 5242880 # 5MB


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 회원가입 API 문서화 및 테스트 코드 부재

**TO-BE**
- Swagger를 활용한 API 문서화 추가
- 유닛 테스트 및 통합 테스트 코드 구현
- 테스트 환경 설정 개선

### 주요 변경사항
1. **API 문서화**
    - springdoc-openapi 의존성 추가
    - API 문서화를 위한 SwaggerConfig 구현
    - UserController에 Swagger 주석 추가
2. **테스트 코드 구현**
    - UserService 단위 테스트 구현
    - UserController 테스트 구현
    - 통합 테스트를 위한 UserApiTest 구현
3. **테스트 환경 설정**
    - 테스트 프로필용 application-test.yml 설정
   - H2 데이터베이스 의존성 추가
    - TestConfig 구현
4. **버그 수정**
    - SignupRequest 비밀번호 정규식 패턴 오류 수정

### 테스트
- [x] 테스트 코드
  - UserServiceTest - 성공
  - UserControllerTest - 실패
  - UserApiTest - 실패
- [ ] API 테스트 
  - Swagger UI 통한 API 테스트 필요

### 이슈 및 제한사항
- 컨트롤러 테스트 및 통합 테스트에서 ApplicationContext 로딩 실패 문제 존재
- 관련 이슈: #3 

### 스크린샷
<img width="382" alt="스크린샷 2025-03-31 오후 12 12 57" src="https://github.com/user-attachments/assets/fe8579e8-818d-4ad4-8fad-bc631a23adb6" />