### PR TITLE
feat: 로그인 기능 핵심 클래스 구현 및 코드 리팩토링

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
@@ -4,7 +4,7 @@ import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
 import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
 import faithcoderlab.newdpraise.domain.user.User;
 import faithcoderlab.newdpraise.domain.user.UserRepository;
-import faithcoderlab.newdpraise.global.security.JwtUtil;
+import faithcoderlab.newdpraise.global.security.JwtProvider;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -22,7 +22,7 @@ public class AuthService {
 
   private final AuthenticationManager authenticationManager;
   private final UserRepository userRepository;
-  private final JwtUtil jwtUtil;
+  private final JwtProvider jwtProvider;
   private final RefreshTokenRepository refreshTokenRepository;
 
   @Transactional
@@ -37,8 +37,8 @@ public class AuthService {
     User user = userRepository.findByEmail(loginRequest.getEmail())
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-    String accessToken = jwtUtil.generateAccessToken(user);
-    String refreshToken = jwtUtil.generateRefreshToken(user);
+    String accessToken = jwtProvider.generateAccessToken(user);
+    String refreshToken = jwtProvider.generateRefreshToken(user);
 
     saveRefreshToken(user.getEmail(), refreshToken);
 
@@ -61,12 +61,12 @@ public class AuthService {
     if (existingToken.isPresent()) {
       refreshToken = existingToken.get();
       refreshToken.setToken(token);
-      refreshToken.setExpiryDate(toLocalDateTime(jwtUtil.extractExpiration(token)));
+      refreshToken.setExpiresAt(toLocalDateTime(jwtProvider.extractExpiration(token)));
     } else {
       refreshToken = RefreshToken.builder()
           .token(token)
           .userEmail(userEmail)
-          .expiryDate(toLocalDateTime(jwtUtil.extractExpiration(token)))
+          .expiresAt(toLocalDateTime(jwtProvider.extractExpiration(token)))
           .build();
     }
 

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
@@ -1,0 +1,79 @@
+package faithcoderlab.newdpraise.domain.auth;
+
+import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.security.JwtUtil;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final AuthenticationManager authenticationManager;
+  private final UserRepository userRepository;
+  private final JwtUtil jwtUtil;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Transactional
+  public LoginResponse login(LoginRequest loginRequest) {
+    authenticationManager.authenticate(
+        new UsernamePasswordAuthenticationToken(
+            loginRequest.getEmail(),
+            loginRequest.getPassword()
+        )
+    );
+
+    User user = userRepository.findByEmail(loginRequest.getEmail())
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+    String accessToken = jwtUtil.generateAccessToken(user);
+    String refreshToken = jwtUtil.generateRefreshToken(user);
+
+    saveRefreshToken(user.getEmail(), refreshToken);
+
+    return LoginResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .instrument(user.getInstrument())
+        .profileImage(user.getProfileImage())
+        .role(user.getRole())
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .build();
+  }
+
+  private void saveRefreshToken(String userEmail, String token) {
+    Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserEmail(userEmail);
+
+    RefreshToken refreshToken;
+    if (existingToken.isPresent()) {
+      refreshToken = existingToken.get();
+      refreshToken.setToken(token);
+      refreshToken.setExpiryDate(toLocalDateTime(jwtUtil.extractExpiration(token)));
+    } else {
+      refreshToken = RefreshToken.builder()
+          .token(token)
+          .userEmail(userEmail)
+          .expiryDate(toLocalDateTime(jwtUtil.extractExpiration(token)))
+          .build();
+    }
+
+    refreshTokenRepository.save(refreshToken);
+  }
+
+  private LocalDateTime toLocalDateTime(Date date) {
+    return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshToken.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshToken.java
@@ -32,7 +32,7 @@ public class RefreshToken {
   private String userEmail;
 
   @Column(nullable = false)
-  private LocalDateTime expiryDate;
+  private LocalDateTime expiresAt;
 
   @Column(nullable = false)
   private LocalDateTime createdAt;
@@ -43,6 +43,6 @@ public class RefreshToken {
   }
 
   public boolean isExpired() {
-    return LocalDateTime.now().isAfter(expiryDate);
+    return LocalDateTime.now().isAfter(expiresAt);
   }
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshTokenRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshTokenRepository.java
@@ -1,8 +1,11 @@
 package faithcoderlab.newdpraise.domain.auth;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  Optional<RefreshToken> findByUserEmail(String userEmail);
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package faithcoderlab.newdpraise.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+  @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+  @Email(message = "유효한 이메일 형식이 아닙니다.")
+  private String email;
+
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+  private String password;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,22 @@
+package faithcoderlab.newdpraise.domain.auth.dto;
+
+import faithcoderlab.newdpraise.domain.user.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginResponse {
+  private Long id;
+  private String email;
+  private String name;
+  private String instrument;
+  private String profileImage;
+  private Role role;
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,16 @@
+package faithcoderlab.newdpraise.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshRequest {
+  @NotBlank(message = "리프레시 토큰은 필수 입력 항목입니다.")
+  private String refreshToken;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,15 @@
+package faithcoderlab.newdpraise.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshResponse {
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/user/CustomUserDetailsService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/user/CustomUserDetailsService.java
@@ -1,6 +1,5 @@
-package faithcoderlab.newdpraise.global.security;
+package faithcoderlab.newdpraise.domain.user;
 
-import faithcoderlab.newdpraise.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/faithcoderlab/newdpraise/global/security/JwtProvider.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/security/JwtProvider.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class JwtUtil {
+public class JwtProvider {
 
   private final JwtProperties jwtProperties;
 

--- a/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
@@ -1,0 +1,102 @@
+package faithcoderlab.newdpraise.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.security.JwtUtil;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private AuthenticationManager authenticationManager;
+
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private RefreshTokenRepository refreshTokenRepository;
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Test
+  @DisplayName("로그인 성공 테스트")
+  void loginSuccess() {
+    // given
+    LoginRequest request = LoginRequest.builder()
+        .email("suming@example.com")
+        .password("password123!")
+        .build();
+
+    User user = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .instrument("피아노")
+        .role(Role.USER)
+        .build();
+
+    when(authenticationManager.authenticate(
+        any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(jwtUtil.generateAccessToken(any(User.class))).thenReturn("access-token");
+    when(jwtUtil.generateRefreshToken(any(User.class))).thenReturn("refresh-token");
+    when(jwtUtil.extractExpiration(anyString())).thenReturn(
+        new Date(System.currentTimeMillis() + 3600000));
+
+    // when
+    LoginResponse response = authService.login(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getEmail()).isEqualTo(user.getEmail());
+    assertThat(response.getName()).isEqualTo(user.getName());
+    assertThat(response.getRole()).isEqualTo(user.getRole());
+    assertThat(response.getAccessToken()).isEqualTo("access-token");
+    assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+
+    verify(refreshTokenRepository).findByUserEmail(user.getEmail());
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 잘못된 자격 증명")
+  void loginFailWithBadCredentials() {
+    // given
+    LoginRequest request = LoginRequest.builder()
+        .email("suming@example.com")
+        .password("wrongpassword")
+        .build();
+
+    when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+        .thenThrow(new BadCredentialsException("잘못된 자격 증명"));
+
+    // when & then
+    assertThatThrownBy(() -> authService.login(request))
+        .isInstanceOf(BadCredentialsException.class);
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
@@ -2,7 +2,6 @@ package faithcoderlab.newdpraise.domain.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -13,7 +12,7 @@ import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
 import faithcoderlab.newdpraise.domain.user.Role;
 import faithcoderlab.newdpraise.domain.user.User;
 import faithcoderlab.newdpraise.domain.user.UserRepository;
-import faithcoderlab.newdpraise.global.security.JwtUtil;
+import faithcoderlab.newdpraise.global.security.JwtProvider;
 import java.util.Date;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +32,7 @@ class AuthServiceTest {
   private AuthenticationManager authenticationManager;
 
   @Mock
-  private JwtUtil jwtUtil;
+  private JwtProvider jwtProvider;
 
   @Mock
   private UserRepository userRepository;
@@ -64,9 +63,9 @@ class AuthServiceTest {
     when(authenticationManager.authenticate(
         any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
     when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
-    when(jwtUtil.generateAccessToken(any(User.class))).thenReturn("access-token");
-    when(jwtUtil.generateRefreshToken(any(User.class))).thenReturn("refresh-token");
-    when(jwtUtil.extractExpiration(anyString())).thenReturn(
+    when(jwtProvider.generateAccessToken(any(User.class))).thenReturn("access-token");
+    when(jwtProvider.generateRefreshToken(any(User.class))).thenReturn("refresh-token");
+    when(jwtProvider.extractExpiration(anyString())).thenReturn(
         new Date(System.currentTimeMillis() + 3600000));
 
     // when


### PR DESCRIPTION
### 변경사항
**AS-IS**
- JWT 토큰 기반 인증을 위한 기반 구조만 존재
- 로그인/로그아웃 API를 위한 DTO 클래스 부재
- 로그인 비즈니스 로직 미구현
- 일부 클래스 이름과 패키지 구조가 불명확

**TO-BE**
- 로그인/로그아웃 토큰 갱신을 위한 DTO 클래스 구현
- AuthService 클래스에 로그인 메서드 구현
- 코드 리뷰 피드백 반영한 리팩토링
  - RefreshToken 필드명 expiryDate → expiresAt 변경
  - JwtUtil → JwtProvider로 클래스명 변경
  - CustomUserDetailsService를 domain/user 패키지로 이동

### 테스트
- [x] 테스트 코드 (AuthService 로그인 메서드 테스트)
- [ ] API 테스트 (컨트롤러 구현 후 진행 예정)

### 주요 구현 내용
1. **로그인/토큰 관련 DTO 클래스**
  - LoginRequest, LoginResponse
  - TokenRefreshRequest, TokenRefreshResponse

2. **로그인 서비스 로직**
  - 사용자 인증 처리
  - JWT 토큰 생성
  - 리프레시 토큰 저장

3. **코드 리팩토링**
  - 클래스명, 필드명 개선
  - 패키지 구조 정리

### 다음 PR 예정 작업
- AuthService의 토큰 갱신 및 로그아웃 메서드 구현
- AuthController 구현 (로그인/로그아웃 API 엔드포인트)
- API 테스트 및 통합 테스트 작성