### PR TITLE
feat: 로그인/로그아웃 API 구현 및 JWT 인증 완성

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
+++ b/src/main/java/faithcoderlab/newdpraise/config/SecurityConfig.java
@@ -1,19 +1,31 @@
 package faithcoderlab.newdpraise.config;
 
+import faithcoderlab.newdpraise.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableJpaAuditing
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final UserDetailsService userDetailsService;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -26,12 +38,30 @@ public class SecurityConfig {
         )
         .authorizeHttpRequests(authorize -> authorize
             .requestMatchers("/users/signup").permitAll()
+            .requestMatchers("/auth/login").permitAll()
+            .requestMatchers("/auth/refresh").permitAll()
             .requestMatchers("/swagger-ui/**").permitAll()
             .requestMatchers("/v3/api-docs/**").permitAll()
             .anyRequest().authenticated()
-        );
+        )
+        .authenticationProvider(authenticationProvider())
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  @Bean
+  public AuthenticationProvider authenticationProvider() {
+    DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+    authProvider.setUserDetailsService(userDetailsService);
+    authProvider.setPasswordEncoder(passwordEncoder());
+    return authProvider;
+  }
+
+  @Bean
+  @Profile("!test")
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+    return config.getAuthenticationManager();
   }
 
   @Bean

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthController.java
@@ -1,0 +1,67 @@
+package faithcoderlab.newdpraise.domain.auth;
+
+import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "로그인 성공",
+          content = @Content(schema = @Schema(implementation = LoginResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터")
+  })
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
+    LoginResponse response = authService.login(loginRequest);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+          content = @Content(schema = @Schema(implementation = TokenRefreshResponse.class))),
+      @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰")
+  })
+  @PostMapping("/refresh")
+  public ResponseEntity<TokenRefreshResponse> refreshToken(
+      @Valid @RequestBody TokenRefreshRequest request
+  ) {
+    TokenRefreshResponse response = authService.refreshToken(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "로그아웃", description = "현재 사용자의 리프레시 토큰을 무효화합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(Principal principal) {
+    authService.logout(principal.getName());
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/AuthService.java
@@ -2,8 +2,11 @@ package faithcoderlab.newdpraise.domain.auth;
 
 import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
 import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshResponse;
 import faithcoderlab.newdpraise.domain.user.User;
 import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
 import faithcoderlab.newdpraise.global.security.JwtProvider;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -52,6 +55,39 @@ public class AuthService {
         .accessToken(accessToken)
         .refreshToken(refreshToken)
         .build();
+  }
+
+  @Transactional
+  public TokenRefreshResponse refreshToken(TokenRefreshRequest request) {
+    String refreshToken = request.getRefreshToken();
+
+    RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+        .orElseThrow(() -> new AuthenticationException("유효하지 않은 리프레시 토큰입니다."));
+
+    if (storedToken.isExpired()) {
+      refreshTokenRepository.delete(storedToken);
+      throw new AuthenticationException("만료된 리프레시 토큰입니다.");
+    }
+
+    User user = userRepository.findByEmail(storedToken.getUserEmail())
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+    String newAccessToken = jwtProvider.generateAccessToken(user);
+    String newRefreshToken = jwtProvider.generateRefreshToken(user);
+
+    storedToken.setToken(newRefreshToken);
+    storedToken.setExpiresAt(toLocalDateTime(jwtProvider.extractExpiration(newRefreshToken)));
+    refreshTokenRepository.save(storedToken);
+
+    return TokenRefreshResponse.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshToken)
+        .build();
+  }
+
+  @Transactional
+  public void logout(String userEmail) {
+    refreshTokenRepository.deleteByUserEmail(userEmail);
   }
 
   private void saveRefreshToken(String userEmail, String token) {

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/CustomUserDetailsService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
-package faithcoderlab.newdpraise.domain.user;
+package faithcoderlab.newdpraise.domain.auth;
 
+import faithcoderlab.newdpraise.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshTokenRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/auth/RefreshTokenRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-
+  Optional<RefreshToken> findByToken(String token);
   Optional<RefreshToken> findByUserEmail(String userEmail);
+  void deleteByUserEmail(String userEmail);
 }

--- a/src/main/java/faithcoderlab/newdpraise/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package faithcoderlab.newdpraise.global.security;
+
+import faithcoderlab.newdpraise.config.JwtProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+  private final UserDetailsService userDetailsService;
+  private final JwtProperties jwtProperties;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    final String authHeader = request.getHeader(jwtProperties.getHeaderString());
+    final String tokenPrefix = jwtProperties.getTokenPrefix();
+
+    String username = null;
+    String jwt = null;
+
+    if (authHeader != null && authHeader.startsWith(tokenPrefix)) {
+      jwt = authHeader.substring(tokenPrefix.length());
+      try {
+        username = jwtProvider.extractUsername(jwt);
+      } catch (Exception e) {
+
+      }
+    }
+
+    if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+      UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+
+      if (jwtProvider.validateToken(jwt, userDetails)) {
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities()
+        );
+
+        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,12 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
+        hbm2ddl:
+          auto: update
+        dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
   security:
     user:

--- a/src/test/java/faithcoderlab/newdpraise/config/TestConfig.java
+++ b/src/test/java/faithcoderlab/newdpraise/config/TestConfig.java
@@ -1,5 +1,7 @@
 package faithcoderlab.newdpraise.config;
 
+import static org.mockito.Mockito.mock;
+
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;

--- a/src/test/java/faithcoderlab/newdpraise/config/TestSecurityConfig.java
+++ b/src/test/java/faithcoderlab/newdpraise/config/TestSecurityConfig.java
@@ -1,0 +1,39 @@
+package faithcoderlab.newdpraise.config;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+  @Bean
+  @Primary
+  public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        )
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/**").permitAll()
+        );
+
+    return http.build();
+  }
+
+  @Bean
+  @Primary
+  public AuthenticationManager authenticationManager() {
+    return mock(AuthenticationManager.class);
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthControllerTest.java
@@ -1,0 +1,136 @@
+package faithcoderlab.newdpraise.domain.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
+import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshResponse;
+import faithcoderlab.newdpraise.domain.user.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestConfig.class, TestSecurityConfig.class})
+class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private AuthService authService;
+
+  @Test
+  @DisplayName("로그인 API 테스트 - 성공")
+  void loginApiSuccess() throws Exception {
+    // given
+    LoginRequest request = LoginRequest.builder()
+        .email("suming@example.com")
+        .password("Password123!")
+        .build();
+
+    LoginResponse response = LoginResponse.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .instrument("피아노")
+        .role(Role.USER)
+        .accessToken("test-access-token")
+        .refreshToken("test-refresh-token")
+        .build();
+
+    when(authService.login(any(LoginRequest.class))).thenReturn(response);
+
+    // when & then
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.email").value("suming@example.com"))
+        .andExpect(jsonPath("$.name").value("수밍"))
+        .andExpect(jsonPath("$.instrument").value("피아노"))
+        .andExpect(jsonPath("$.role").value("USER"))
+        .andExpect(jsonPath("$.accessToken").value("test-access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("test-refresh-token"));
+  }
+
+  @Test
+  @DisplayName("로그인 API 테스트 - 유효성 검사 실패")
+  void loginApiValidationFail() throws Exception {
+    // given
+    LoginRequest request = LoginRequest.builder()
+        .email("invalid-email")
+        .password("")
+        .build();
+
+    // when & then
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 API 테스트 - 성공")
+  void refreshTokenApiSuccess() throws Exception {
+    // given
+    TokenRefreshRequest request = new TokenRefreshRequest("valid-refresh-token");
+
+    TokenRefreshResponse response = TokenRefreshResponse.builder()
+        .accessToken("new-access-token")
+        .refreshToken("new-refresh-token")
+        .build();
+
+    when(authService.refreshToken(any(TokenRefreshRequest.class))).thenReturn(response);
+
+    // when & then
+    mockMvc.perform(post("/auth/refresh")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+        .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"));
+  }
+
+  @Test
+  @DisplayName("로그아웃 API 테스트 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void logoutApiSuccess() throws Exception {
+    // given
+    doNothing().when(authService).logout(anyString());
+
+    // when & then
+    mockMvc.perform(post("/auth/logout"))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthServiceTest.java
@@ -4,15 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import faithcoderlab.newdpraise.domain.auth.dto.LoginRequest;
 import faithcoderlab.newdpraise.domain.auth.dto.LoginResponse;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshRequest;
+import faithcoderlab.newdpraise.domain.auth.dto.TokenRefreshResponse;
 import faithcoderlab.newdpraise.domain.user.Role;
 import faithcoderlab.newdpraise.domain.user.User;
 import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
 import faithcoderlab.newdpraise.global.security.JwtProvider;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -97,5 +102,82 @@ class AuthServiceTest {
     // when & then
     assertThatThrownBy(() -> authService.login(request))
         .isInstanceOf(BadCredentialsException.class);
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 성공")
+  void refreshTokenSuccess() {
+    // given
+    TokenRefreshRequest request = new TokenRefreshRequest("valid-refresh-token");
+
+    RefreshToken refreshToken = RefreshToken.builder()
+        .id(1L)
+        .token("valid-refresh-token")
+        .userEmail("suming@example.com")
+        .expiresAt(LocalDateTime.now().plusDays(7))
+        .build();
+
+    User user = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .build();
+
+    when(refreshTokenRepository.findByToken(anyString())).thenReturn(Optional.of(refreshToken));
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+    when(jwtProvider.generateAccessToken(any(User.class))).thenReturn("new-access-token");
+    when(jwtProvider.generateRefreshToken(any(User.class))).thenReturn("new-refresh-token");
+    when(jwtProvider.extractExpiration(anyString())).thenReturn(new Date(System.currentTimeMillis() + 3600000));
+    when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(refreshToken);
+
+    // when
+    TokenRefreshResponse response = authService.refreshToken(request);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+    assertThat(response.getRefreshToken()).isEqualTo("new-refresh-token");
+
+    verify(refreshTokenRepository).findByToken("valid-refresh-token");
+    verify(refreshTokenRepository).save(any(RefreshToken.class));
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 실패 - 만료된 리프레시 토큰")
+  void refreshTokenFailWithExpiredToken() {
+    // given
+    TokenRefreshRequest request = new TokenRefreshRequest("expired-refresh-token");
+
+    RefreshToken refreshToken = RefreshToken.builder()
+        .id(1L)
+        .token("expired-refresh-token")
+        .userEmail("suming@example.com")
+        .expiresAt(LocalDateTime.now().minusDays(1))
+        .build();
+
+    when(refreshTokenRepository.findByToken(anyString())).thenReturn(Optional.of(refreshToken));
+
+    // when & then
+    assertThatThrownBy(() -> authService.refreshToken(request))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessage("만료된 리프레시 토큰입니다.");
+
+    verify(refreshTokenRepository).findByToken("expired-refresh-token");
+    verify(refreshTokenRepository).delete(refreshToken);
+  }
+
+  @Test
+  @DisplayName("로그아웃 성공")
+  void logoutSuccess() {
+    // given
+    String userEmail = "suming@example.com";
+    doNothing().when(refreshTokenRepository).deleteByUserEmail(anyString());
+
+    // when
+    authService.logout(userEmail);
+
+    // then
+    verify(refreshTokenRepository).deleteByUserEmail(userEmail);
   }
 }

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserApiTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
 import faithcoderlab.newdpraise.domain.user.dto.SignUpRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Import(faithcoderlab.newdpraise.config.TestConfig.class)
+@Import({TestConfig.class, TestSecurityConfig.class})
 @ActiveProfiles("test")
 @Transactional
 public class UserApiTest {

--- a/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/user/UserControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
 import faithcoderlab.newdpraise.domain.user.dto.SignUpRequest;
 import faithcoderlab.newdpraise.domain.user.dto.SignUpResponse;
 import java.time.LocalDateTime;
@@ -30,7 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import(TestConfig.class)
+@Import({TestConfig.class, TestSecurityConfig.class})
 class UserControllerTest {
 
   @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,11 +12,11 @@ spring:
         format_sql: true
         show_sql: true
     database-platform: org.hibernate.dialect.H2Dialect
-#logging:
-#  level:
-#    org.springframework: DEBUG
-#    org.hibernate: DEBUG
-#    faithcoderlab.newdpraise: DEBUG
+logging:
+  level:
+    org.springframework: DEBUG
+    org.hibernate: DEBUG
+    faithcoderlab.newdpraise: DEBUG
 
 
 # Youtube API 설정


### PR DESCRIPTION
### 변경사항
**AS-IS**
- JWT 기반 인증을 위한 기초 구조만 구현되어 있었음
- AuthService의 로그인 메서드만 구현되어 있었음
- 인증 필터 및 보안 설정이 구현되어 있지 않았음

**TO-BE**
- AuthService 클래스에 토큰 갱신 및 로그아웃 메서드 구현
- AuthController 구현 및 관련 API 엔드포인트 제공
  - 로그인(/auth/login)
  - 토큰 재발급(/auth/refresh)
  - 로그아웃(/auth/logout)
- JwtAuthenticationFilter 구현하여 요청 헤더에서 토큰 처리
- SecurityConfig 업데이트 → JWT 인증 필터 등록 및 보안 설정
- 테스트 환경 설정 개선(TestSecurityConfig)

### 테스트
- [x] 테스트 코드
- [x] API 테스트 

### 버그 수정
- **RefreshToken 엔티티와 데이터베이스 스키마 불일치 해결 (#10)**
  - RefreshToken 엔티티의 expiresAt 필드 매핑 수정
  - 데이터베이스 스키마 업데이트 (expiry_date → expires_at)
  - 필드명과 컬럼명 간 일관성 확보
  
### Swagger 테스트
1. **로그인 API**
<img width="411" alt="스크린샷 2025-04-07 오후 3 50 24" src="https://github.com/user-attachments/assets/f7de5e73-6e7c-4c71-b1e1-e43f8ee8b82c" />

2. **토큰 재발급 API**
<img width="397" alt="스크린샷 2025-04-07 오후 3 52 22" src="https://github.com/user-attachments/assets/35d815e1-130c-4450-82ae-2975e8530695" />

3. **로그아웃 API**
<img width="397" alt="스크린샷 2025-04-07 오후 3 54 32" src="https://github.com/user-attachments/assets/e4876518-9e13-477d-9926-d53b6c9bb609" />
