### PR TITLE
feat: 콘티 텍스트 파싱 알고리즘 구현

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/Conti.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/Conti.java
@@ -1,0 +1,90 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import faithcoderlab.newdpraise.domain.user.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "conti")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Conti {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Column(nullable = false)
+  private LocalDate performanceDate;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id")
+  private User creator;
+
+  @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+  @JoinTable(
+      name = "conti_songs",
+      joinColumns = @JoinColumn(name = "conti_id"),
+      inverseJoinColumns = @JoinColumn(name = "song_id")
+  )
+  @OrderColumn(name = "position")
+  private List<Song> songs = new ArrayList<>();
+
+  @Column(nullable = false)
+  private String version;
+
+  @Column(columnDefinition = "TEXT")
+  private String originalText;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ContiStatus status;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+    updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
@@ -1,0 +1,353 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import faithcoderlab.newdpraise.domain.user.User;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContiParserService {
+
+  private static final Pattern DATE_PATTERN = Pattern.compile(
+      "\\d{8}|" +
+          "\\d{4}[-./]\\d{1,2}[-./]\\d{1,2}|" +
+          "\\d{4}년\\s*\\d{1,2}월\\s*\\d{1,2}일|" +
+          "\\d{1,2}[-./]\\d{1,2}[-./]\\d{4}|" +
+          "\\d{1,2}[-./]\\d{1,2}"
+  );
+
+  private static final Pattern SONG_LINE_PATTERN = Pattern.compile(
+      "(?im)^\\s*(?:(\\d+)[.\\s]+)([^\\r\\n]+)$");
+
+  private static final Pattern KEY_PATTERN = Pattern.compile(
+      "\\b([A-Ga-g][#b♯♭]?m?(?:-[A-Ga-g][#b♯♭]?m?)?)\\b");
+
+  private static final Pattern YOUTUBE_URL_PATTERN = Pattern.compile(
+      "(?:https?://)?(?:www\\.)?(?:youtube\\.com/watch\\?v=|youtu\\.be/)([a-zA-Z0-9_-]{11})(?:[?&][^\\s]*)?");
+
+  private static final Pattern BPM_PATTERN = Pattern.compile(
+      "\\b(?:BPM|템포)[:\\s]*([0-9]+)\\b");
+
+  private static final Pattern ARTIST_PATTERN = Pattern.compile(
+      "/\\s*([^/\\r\\n]+)(?:\\s*$|\\s*(?=[/\\(\\[]))");
+
+  private static final Pattern THEME_PATTERN = Pattern.compile(
+      "(?i)주제\\s*[:\\s]+(.+)$");
+
+  private final SongRepository songRepository;
+
+  public Conti parseContiText(String contiText, User creator) {
+    log.debug("콘티 텍스트 파싱 시작: {} 글자", contiText.length());
+
+    String title = extractThemeAsTitle(contiText);
+
+    if (title == null || title.isEmpty()) {
+      String[] lines = contiText.split("\\r?\\n");
+      title = extractTitle(lines);
+    }
+
+    LocalDate performanceDate = extractDate(contiText);
+
+    List<Song> songs = extractSongs(contiText);
+
+    Conti conti = Conti.builder()
+        .title(title)
+        .performanceDate(performanceDate != null ? performanceDate : LocalDate.now())
+        .creator(creator)
+        .songs(songs)
+        .version("1.0")
+        .originalText(contiText)
+        .status(ContiStatus.DRAFT)
+        .build();
+
+    log.debug("콘티 파싱 완료: 제목={}, 날짜={}, 곡 수={}",
+        conti.getTitle(), conti.getPerformanceDate(), conti.getSongs().size());
+
+    return conti;
+  }
+
+  private String extractThemeAsTitle(String text) {
+    Pattern themePattern = Pattern.compile("(?i)주제\\s*[:\\s]+(.+)$", Pattern.MULTILINE);
+    Matcher matcher = themePattern.matcher(text);
+    if (matcher.find()) {
+      return matcher.group(1).trim();
+    }
+    return null;
+  }
+
+  private String extractTitle(String[] lines) {
+    if (lines.length == 0) {
+      return "무제";
+    }
+
+    String firstLine = lines[0].trim();
+
+    return firstLine.isEmpty() ? "무제" : firstLine;
+  }
+
+  private LocalDate extractDate(String text) {
+    Matcher matcher = DATE_PATTERN.matcher(text);
+    if (matcher.find()) {
+      String dateStr = matcher.group();
+
+      try {
+        if (dateStr.matches("\\d{8}")) {
+          int year = Integer.parseInt(dateStr.substring(0, 4));
+          int month = Integer.parseInt(dateStr.substring(4, 6));
+          int day = Integer.parseInt(dateStr.substring(6, 8));
+          return LocalDate.of(year, month, day);
+        }
+
+        Matcher ymdMatcher = Pattern.compile("(\\d{4})[-./](\\d{1,2})[-./](\\d{1,2})").matcher(dateStr);
+        if (ymdMatcher.find()) {
+          int year = Integer.parseInt(ymdMatcher.group(1));
+          int month = Integer.parseInt(ymdMatcher.group(2));
+          int day = Integer.parseInt(ymdMatcher.group(3));
+          return LocalDate.of(year, month, day);
+        }
+
+        Matcher koreanMatcher = Pattern.compile("(\\d{4})년\\s*(\\d{1,2})월\\s*(\\d{1,2})일").matcher(dateStr);
+        if (koreanMatcher.find()) {
+          int year = Integer.parseInt(koreanMatcher.group(1));
+          int month = Integer.parseInt(koreanMatcher.group(2));
+          int day = Integer.parseInt(koreanMatcher.group(3));
+          return LocalDate.of(year, month, day);
+        }
+
+        Matcher mdyMatcher = Pattern.compile("(\\d{1,2})[-./](\\d{1,2})[-./](\\d{4})").matcher(dateStr);
+        if (mdyMatcher.find()) {
+          int month = Integer.parseInt(mdyMatcher.group(1));
+          int day = Integer.parseInt(mdyMatcher.group(2));
+          int year = Integer.parseInt(mdyMatcher.group(3));
+          return LocalDate.of(year, month, day);
+        }
+
+        Matcher mdMatcher = Pattern.compile("(\\d{1,2})[-./](\\d{1,2})").matcher(dateStr);
+        if (mdMatcher.find() && !mdyMatcher.find()) {
+          int month = Integer.parseInt(mdMatcher.group(1));
+          int day = Integer.parseInt(mdMatcher.group(2));
+          return LocalDate.of(LocalDate.now().getYear(), month, day);
+        }
+
+        log.warn("인식할 수 없는 날짜 형식: {}", dateStr);
+      } catch (Exception e) {
+        log.warn("날짜 파싱 실패: {}", dateStr, e);
+      }
+    }
+
+    return LocalDate.now();
+  }
+
+  private List<Song> extractSongs(String text) {
+    List<Song> songs = new ArrayList<>();
+    String[] lines = text.split("\\r?\\n");
+
+    boolean foundSongLine = false;
+
+    for (int i = 0; i < lines.length; i++) {
+      String line = lines[i].trim();
+
+      if (line.isEmpty()) {
+        continue;
+      }
+
+      if (line.matches("(?i).*주제\\s*[:\\s]+.*")) {
+        continue;
+      }
+
+      if (i == 0) {
+        continue;
+      }
+
+      Matcher songNumberMatcher = Pattern.compile("^\\s*(\\d+)[.\\s]+").matcher(line);
+      if (songNumberMatcher.find()) {
+        foundSongLine = true;
+
+        String songLine = line.substring(songNumberMatcher.end()).trim();
+
+        String title = extractSongTitle(songLine);
+        String key = extractKey(songLine);
+        String artist = extractArtist(songLine);
+
+        StringBuilder additionalInfo = new StringBuilder();
+        int j = i + 1;
+        while (j < lines.length) {
+          String nextLine = lines[j].trim();
+
+          if (nextLine.isEmpty() ||
+              nextLine.matches("^\\s*\\d+[.\\s]+.*") ||
+              nextLine.matches("(?i).*주제\\s*[:\\s]+.*")) {
+            break;
+          }
+
+          additionalInfo.append(nextLine).append("\n");
+          j++;
+        }
+
+        String youtubeUrl = extractYoutubeUrl(additionalInfo.toString());
+        if (youtubeUrl == null) {
+          youtubeUrl = extractYoutubeUrl(songLine);
+        }
+
+        String specialInstructions = extractSpecialInstructions(
+            songLine + "\n" + additionalInfo.toString(),
+            title, key, artist, youtubeUrl
+        );
+
+        if (title != null && !title.isEmpty()) {
+          Song song = Song.builder()
+              .title(title)
+              .originalKey(key)
+              .performanceKey(key)
+              .artist(artist)
+              .youtubeUrl(youtubeUrl)
+              .specialInstructions(specialInstructions)
+              .build();
+
+          songs.add(song);
+        }
+      } else if (!foundSongLine) {
+        continue;
+      }
+    }
+
+    return songs;
+  }
+
+  private String extractSongTitle(String songLine) {
+    String line = songLine.replaceAll(YOUTUBE_URL_PATTERN.pattern(), "").trim();
+
+    int slashIndex = line.indexOf('/');
+    if (slashIndex > 0) {
+      line = line.substring(0, slashIndex).trim();
+    }
+
+    line = line.replaceAll("\\([^)]*\\)", "").replaceAll("\\[[^\\]]*\\]", "").trim();
+
+    String[] words = line.split("\\s+");
+    StringBuilder titleBuilder = new StringBuilder();
+
+    for (int i = 0; i < words.length; i++) {
+      String word = words[i];
+
+      if (i >= words.length - 2 && isKeyPattern(word)) {
+        continue;
+      }
+
+      if (titleBuilder.length() > 0) {
+        titleBuilder.append(" ");
+      }
+      titleBuilder.append(word);
+    }
+
+    return titleBuilder.toString().trim();
+  }
+
+  private boolean isKeyPattern(String text) {
+    if (text.matches("[A-Ga-g][#b♯♭]?m?")) {
+      return true;
+    }
+
+    if (text.matches("[A-Ga-g][#b♯♭]?m?(?:->|[-])[A-Ga-g][#b♯♭]?m?")) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private String extractKey(String songLine) {
+    String[] words = songLine.split("\\s+");
+
+    for (int i = words.length - 1; i >= 0; i--) {
+      String word = words[i];
+
+      if (isKeyPattern(word)) {
+        return word;
+      }
+    }
+
+    return null;
+  }
+
+  private String extractArtist(String songLine) {
+    int slashIndex = songLine.indexOf('/');
+    if (slashIndex >= 0 && slashIndex + 1 < songLine.length()) {
+      String artistPart = songLine.substring(slashIndex + 1).trim();
+
+      artistPart = artistPart.replaceAll("\\([^)]*\\)", "").trim();
+
+      int bracketIndex = artistPart.indexOf('(');
+      if (bracketIndex > 0) {
+        artistPart = artistPart.substring(0, bracketIndex).trim();
+      }
+
+      int nextSlashIndex = artistPart.indexOf('/');
+      if (nextSlashIndex > 0) {
+        artistPart = artistPart.substring(0, nextSlashIndex).trim();
+      }
+
+      return artistPart;
+    }
+    return null;
+  }
+
+  private String extractYoutubeUrl(String songLine) {
+    Matcher matcher = YOUTUBE_URL_PATTERN.matcher(songLine);
+    if (matcher.find()) {
+      String videoId = matcher.group(1);
+      return "https://youtube.com/watch?v=" + matcher.group(1);
+    }
+    return null;
+  }
+
+  private String extractSpecialInstructions(String songLine, String title, String key, String artist, String youtubeUrl) {
+    String line = songLine;
+
+    if (title != null) {
+      line = line.replaceAll(title, "");
+    }
+
+    if (key != null) {
+      line = line.replaceAll(key, "");
+    }
+
+    if (artist != null) {
+      line = line.replace("/ " + artist, "").replace("/" + artist, "");
+    }
+
+    if (youtubeUrl != null) {
+      Matcher matcher = YOUTUBE_URL_PATTERN.matcher(songLine);
+      if (matcher.find()) {
+        line = line.replace(matcher.group(), "");
+      }
+    }
+
+    StringBuilder instructions = new StringBuilder();
+    Matcher bracketMatcher = Pattern.compile("\\(([^)]*)\\)|\\[([^\\]]*)\\]").matcher(line);
+
+    while (bracketMatcher.find()) {
+      String content =
+          bracketMatcher.group(1) != null ? bracketMatcher.group(1) : bracketMatcher.group(2);
+      if (content != null && !content.isEmpty()) {
+        instructions.append(content.trim()).append("\n");
+      }
+    }
+
+    line = line.replaceAll("\\([^)]*\\)", "").replaceAll("\\[[^\\]]*\\]", "");
+    line = line.replaceAll("\\s+", " ").trim();
+
+    if (!line.isEmpty()) {
+      instructions.append(line);
+    }
+
+    String result = instructions.toString().trim();
+    return result.isEmpty() ? null : result;
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiRepository.java
@@ -1,0 +1,8 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContiRepository extends JpaRepository<Conti, Long> {
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiStatus.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiStatus.java
@@ -1,0 +1,7 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+public enum ContiStatus {
+  DRAFT, // 초안
+  FINALIZED, // 확정됨
+  ARCHIVED // 보관됨
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/Song.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/Song.java
@@ -1,0 +1,63 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "songs")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Song {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  private String originalKey;
+
+  private String performanceKey;
+
+  private String artist;
+
+  private String youtubeUrl;
+
+  private Integer durationSeconds;
+
+  @Column(columnDefinition = "TEXT")
+  private String specialInstructions;
+
+  private String bpm;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+    updatedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/SongRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/SongRepository.java
@@ -1,0 +1,9 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SongRepository extends JpaRepository<Song, Long> {
+
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiParseRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiParseRequest.java
@@ -1,0 +1,14 @@
+package faithcoderlab.newdpraise.domain.conti.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiParseRequest {
+  private String contiText;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiParseResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiParseResponse.java
@@ -1,0 +1,33 @@
+package faithcoderlab.newdpraise.domain.conti.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiParseResponse {
+  private String title;
+  private LocalDate performanceDate;
+  private List<SongDto> songs;
+  private String version;
+  private String status;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SongDto {
+    private String title;
+    private String originalKey;
+    private String performanceKey;
+    private String youtubeUrl;
+    private String specialInstructions;
+    private String bpm;
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiParserServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiParserServiceTest.java
@@ -1,0 +1,220 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContiParserServiceTest {
+
+  @Mock
+  private SongRepository songRepository;
+
+  @InjectMocks
+  private ContiParserService contiParserService;
+
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("기본 콘티 텍스트 파싱 테스트")
+  void parseBasicContiText() {
+    // given
+    String contiText = "20250405 찬양집회 콘티\n\n" +
+        "1. 물댄 동산 G (교제송) \n\n" +
+        "2. 정직한 예배 G-Ab / 제이어스\n" +
+        "https://youtu.be/R9tUikvBv5M?si=_Njl-T7VYU7c1hvb\n\n" +
+        "3. 아름다우신 Ab / 캠퍼스워십\n\n" +
+        "주제 : Alive";
+
+    // when
+    Conti result = contiParserService.parseContiText(contiText, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("Alive");
+    assertThat(result.getPerformanceDate()).isEqualTo(LocalDate.of(2025, 4, 5));
+    assertThat(result.getCreator()).isEqualTo(testUser);
+    assertThat(result.getSongs()).hasSize(3);
+
+    Song firstSong = result.getSongs().get(0);
+    assertThat(firstSong.getTitle()).isEqualTo("물댄 동산");
+    assertThat(firstSong.getPerformanceKey()).isEqualTo("G");
+    assertThat(firstSong.getSpecialInstructions()).contains("교제송");
+    assertThat(firstSong.getYoutubeUrl()).isNull();
+
+    Song secondSong = result.getSongs().get(1);
+    assertThat(secondSong.getTitle()).isEqualTo("정직한 예배");
+    assertThat(secondSong.getPerformanceKey()).isEqualTo("G-Ab");
+    assertThat(secondSong.getArtist()).isEqualTo("제이어스");
+    assertThat(secondSong.getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=R9tUikvBv5M");
+
+    Song thirdSong = result.getSongs().get(2);
+    assertThat(thirdSong.getTitle()).isEqualTo("아름다우신");
+    assertThat(thirdSong.getPerformanceKey()).isEqualTo("Ab");
+    assertThat(thirdSong.getArtist()).isEqualTo("캠퍼스워십");
+  }
+
+  @Test
+  @DisplayName("다양한 날짜 형식 파싱 테스트")
+  void parseDifferentDateFormats() {
+    // given
+    LocalDate expectedDate = LocalDate.of(2025, 4, 5);
+
+    String yyyymmdd = "20250405 콘티\n1. 테스트 곡 E";
+    Conti result1 = contiParserService.parseContiText(yyyymmdd, testUser);
+    assertThat(result1.getPerformanceDate())
+        .as("Failed for YYYYMMDD format")
+        .isEqualTo(expectedDate);
+
+    String yyyyDashMmDashDd = "2025-04-05 콘티\n1. 테스트 곡 E";
+    Conti result2 = contiParserService.parseContiText(yyyyDashMmDashDd, testUser);
+    assertThat(result2.getPerformanceDate())
+        .as("Failed for YYYY-MM-DD format")
+        .isEqualTo(expectedDate);
+
+    String yyyySlashMmSlashDd = "2025/04/05 콘티\n1. 테스트 곡 E";
+    Conti result3 = contiParserService.parseContiText(yyyySlashMmSlashDd, testUser);
+    assertThat(result3.getPerformanceDate())
+        .as("Failed for YYYY/MM/DD format")
+        .isEqualTo(expectedDate);
+
+    String koreanFormat = "2025년 4월 5일 콘티\n1. 테스트 곡 E";
+    Conti result4 = contiParserService.parseContiText(koreanFormat, testUser);
+    assertThat(result4.getPerformanceDate())
+        .as("Failed for Korean date format")
+        .isEqualTo(expectedDate);
+
+    String mmSlashDd = "04/05 콘티\n1. 테스트 곡 E";
+    Conti result5 = contiParserService.parseContiText(mmSlashDd, testUser);
+    assertThat(result5.getPerformanceDate())
+        .as("Failed for MM/DD format")
+        .isEqualTo(LocalDate.of(LocalDate.now().getYear(), 4, 5));
+  }
+
+  @Test
+  @DisplayName("유튜브 URL 다양한 형식 파싱 테스트")
+  void parseYoutubeUrls() {
+    // given
+    String contiText = "테스트 콘티\n\n" +
+        "1. 곡1 C\n" +
+        "https://youtube.com/watch?v=abcdef12345\n\n" +
+        "2. 곡2 D\n" +
+        "https://youtu.be/ghijk67890a\n\n" +
+        "3. 곡3 E\n" +
+        "유튜브: https://youtube.com/watch?v=lmnopq12345&t=120\n\n";
+
+    // when
+    Conti result = contiParserService.parseContiText(contiText, testUser);
+
+    // then
+    assertThat(result.getSongs()).hasSize(3);
+    assertThat(result.getSongs().get(0).getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=abcdef12345");
+    assertThat(result.getSongs().get(1).getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=ghijk67890a");
+    assertThat(result.getSongs().get(2).getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=lmnopq12345");
+  }
+
+  @Test
+  @DisplayName("복잡한 콘티 예제 파싱 테스트")
+  void parseComplexContiExample() {
+    // given
+    String contiText = "20250111 찬양집회\n\n" +
+        "1. 주님의 시간에 C->D (76)\n" +
+        "일단 레퍼런스대로\n" +
+        "http://cafe.naver.com/naehansarang79/140\n\n" +
+        "2. 나의 왕 나의 주 A / J-US (이사랑 인도)\n" +
+        "레퍼런스대로\n" +
+        "https://youtu.be/7U6n-xgn8U8?si=VXD2SEgk7QtDCoE7\n\n" +
+        "3. winning all A / 캠퍼스워십\n" +
+        "템포는 2번곡과 같이\n" +
+        "https://youtu.be/_wc0uJTmtSQ?si=sraRjN0R4XWdSTsH 39초부터\n\n" +
+        "주제 : Children of God\n\n" +
+        "악보는 어디까지나 참고…\n" +
+        "수정이 필요하면 수정햐주세요";
+
+    // when
+    Conti result = contiParserService.parseContiText(contiText, testUser);
+
+    // then
+    assertThat(result.getTitle()).isEqualTo("Children of God");
+    assertThat(result.getPerformanceDate()).isEqualTo(LocalDate.of(2025, 1, 11));
+    assertThat(result.getSongs()).hasSize(3);
+
+    Song firstSong = result.getSongs().get(0);
+    assertThat(firstSong.getTitle()).isEqualTo("주님의 시간에");
+    assertThat(firstSong.getOriginalKey()).isEqualTo("C->D");
+    assertThat(firstSong.getSpecialInstructions()).contains("76");
+    assertThat(firstSong.getSpecialInstructions()).contains("일단 레퍼런스대로");
+
+    Song secondSong = result.getSongs().get(1);
+    assertThat(secondSong.getTitle()).isEqualTo("나의 왕 나의 주");
+    assertThat(secondSong.getOriginalKey()).isEqualTo("A");
+    assertThat(secondSong.getArtist()).isEqualTo("J-US");
+    assertThat(secondSong.getSpecialInstructions()).contains("이사랑 인도");
+    assertThat(secondSong.getSpecialInstructions()).contains("레퍼런스대로");
+    assertThat(secondSong.getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=7U6n-xgn8U8");
+
+    Song thirdSong = result.getSongs().get(2);
+    assertThat(thirdSong.getTitle()).isEqualTo("winning all");
+    assertThat(thirdSong.getOriginalKey()).isEqualTo("A");
+    assertThat(thirdSong.getArtist()).isEqualTo("캠퍼스워십");
+    assertThat(thirdSong.getSpecialInstructions()).contains("템포는 2번곡과 같이");
+    assertThat(thirdSong.getYoutubeUrl()).isEqualTo("https://youtube.com/watch?v=_wc0uJTmtSQ");
+  }
+
+  @Test
+  @DisplayName("creator가 null인 경우 테스트")
+  void parseContiTextWithNullCreator() {
+    // given
+    String contiText = "20250405 찬양집회 콘티\n" +
+        "1. 물댄 동산 G (교제송)";
+
+    // when
+    Conti result = contiParserService.parseContiText(contiText, null);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getCreator()).isNull();
+    assertThat(result.getTitle()).isEqualTo("20250405 찬양집회 콘티");
+    assertThat(result.getPerformanceDate()).isEqualTo(LocalDate.of(2025, 4, 5));
+  }
+
+  @Test
+  @DisplayName("주제가 없는 경우 첫 줄에서 제목 추출 테스트")
+  void parseTitleFromFirstLineWhenNoTheme() {
+    // given
+    String contiText = "2025년 2월 15일 찬양집회 콘티\n\n" +
+        "1. 나 주님이 더욱 필요해 D-E\n" +
+        "세션은 따로 카피 안할게요.\n" +
+        "연습때 잠깐 맞춰봅시다.";
+
+    // when
+    Conti result = contiParserService.parseContiText(contiText, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("2025년 2월 15일 찬양집회 콘티");
+    assertThat(result.getPerformanceDate()).isEqualTo(LocalDate.of(2025, 2, 15));
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 콘티와 곡 정보를 저장할 데이터 모델이 없었음
- 구조화되지 않은 텍스트 형태의 콘티를 수동으로 파싱해야 했음
- 다양한 형식의 날짜, 곡 정보, 유튜브 링크 등의 정보를 추출하는 기능이 없었음

**TO-BE**
- Song과 Conti 엔티티 모델 설계 및 구현
- 텍스트 형태의 콘티를 자동으로 파싱하는 알고리즘 구현
- 다양한 날짜 형식 지원
- 곡 정보 추출(제목, 키, 아티스트, 유튜브 링크)
- 특별 지시사항 파싱 기능
- "주제 : " 패턴을 자동으로 인식하여 제목으로 설정
- 콘티 안의 다양한 정보를 정규표현식을 활용하여 정확하게 추출 (각 정규표현식 작성부분은 GPT 도움 받음)

### 테스트
- [x] 테스트 코드
  - 기본 콘티  텍스트 파싱 테스트
  - 다양한 날짜 형식 파싱 테스트
  - 유튜브 URL 다양한 형식 파싱 테스트
  - 복잡한 콘티 예제 파싱 테스트
  - creator가 null인 경우 테스트
  - 주제가 없는 경우 첫 줄에서 제목 추출 테스트
- [ ] API 테스트 

### 향후 개발 계획
- Controller 작성 및 API 테스트 구현
- 유튜브 링크 외 다른 외부 링크도 처리할 수 있도록 기능 확장
- Original key 및 BPM 정보를 유튜브 링크의 곡을 분석하여 추출하는 기능 개발