### PR TITLE
fix: JWT 예외 처리 및 테스트 개선

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/security/JwtAuthenticationFilter.java
@@ -1,12 +1,17 @@
 package faithcoderlab.newdpraise.global.security;
 
 import faithcoderlab.newdpraise.config.JwtProperties;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,6 +20,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -36,8 +42,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       jwt = authHeader.substring(tokenPrefix.length());
       try {
         username = jwtProvider.extractUsername(jwt);
+      } catch (ExpiredJwtException e) {
+        log.debug("만료된 JWT 토큰입니다: {}", e.getMessage());
+      } catch (UnsupportedJwtException e) {
+        log.debug("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+      } catch (MalformedJwtException e) {
+        log.debug("JWT 토큰이 올바르게 구성되지 않았습니다: {}", e.getMessage());
+      } catch (SignatureException e) {
+        log.debug("JWT 서명 검증에 실패했습니다: {}", e.getMessage());
+      } catch (IllegalArgumentException e) {
+        log.debug("JWT 클레임 문자열이 비어 있습니다: {}", e.getMessage());
       } catch (Exception e) {
-
+        log.error("JWT 토큰 처리 중 예상치 못한 오류가 발생했습니다", e);
       }
     }
 

--- a/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/auth/AuthControllerTest.java
@@ -95,7 +95,11 @@ class AuthControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andDo(print())
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.message").value("유효성 검증에 실패했습니다."))
+        .andExpect(jsonPath("$.errors.email").value("유효한 이메일 형식이 아닙니다."))
+        .andExpect(jsonPath("$.errors.password").value("비밀번호는 필수 입력 항목입니다."));
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
**AS-IS**
- JwtAuthenticationFilter에서 JWT 토큰 검증 실패 시 catch 블록이 비어 있었음
- AuthService의 사용자 조회 실패에 대한 테스트 케이스 부재
- AuthControllerTest에서 상태 코드만 검증하고 응답 메시지는 검증하지 않음

**TO-BE**
- JwtAuthenticationFilter에 구체적인 예외 처리 및 로깅 추가
- AuthService의 refreshToken 메서드에서 사용자를 찾지 못하는 상황에 대한 테스트 케이스 추가
- AuthControllerTest에 응답 바디 및 오류 메시지 검증 로직 추가