### PR TITLE
feat: 콘티 업로드 및 관리 API 구현

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiController.java
@@ -1,0 +1,167 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import faithcoderlab.newdpraise.domain.conti.dto.ContiCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiParseRequest;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiParseResponse;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiResponse;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/conti")
+@RequiredArgsConstructor
+@Tag(name = "Conti", description = "콘티 관련 API")
+public class ContiController {
+
+  private final ContiParserService contiParserService;
+  private final ContiService contiService;
+  private final UserRepository userRepository;
+
+  @Operation(summary = "콘티 텍스트 파싱", description = "텍스트 형태의 콘티를 파싱하여 구조화된 데이터로 변환합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "파싱 성공",
+          content = @Content(schema = @Schema(implementation = ContiParseResponse.class))),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @PostMapping("/parse")
+  public ResponseEntity<ContiParseResponse> parseContiText(
+      @Valid @RequestBody ContiParseRequest request, Principal principal
+  ) {
+
+    User user = getUserFromPrincipal(principal);
+    Conti conti = contiParserService.parseContiText(request.getContiText(), user);
+    ContiParseResponse response = mapToParseResponse(conti);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "콘티 생성", description = "새로운 콘티를 생성합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "콘티 생성 성공",
+          content = @Content(schema = @Schema(implementation = ContiResponse.class))),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @PostMapping
+  public ResponseEntity<ContiResponse> createConti(
+      @Valid @RequestBody ContiCreateRequest request, Principal principal
+  ) {
+
+    User user = getUserFromPrincipal(principal);
+    Conti conti = contiService.createConti(request, user);
+    ContiResponse response = mapToContiResponse(conti);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "콘티 목록 조회", description = "사용자의 콘티 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping
+  public ResponseEntity<List<ContiResponse>> getContiList(Principal principal) {
+    User user = getUserFromPrincipal(principal);
+    List<Conti> contiList = contiService.getUserContiList(user);
+    List<ContiResponse> responseList = contiList.stream()
+        .map(this::mapToContiResponse)
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responseList);
+  }
+
+  @Operation(summary = "콘티 상세 조회", description = "특정 콘티의 상세 정보를 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공",
+          content = @Content(schema = @Schema(implementation = ContiResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "404", description = "콘티를 찾을 수 없음")
+  })
+  @GetMapping("/{contiId}")
+  public ResponseEntity<ContiResponse> getContiDetail(
+      @PathVariable Long contiId, Principal principal
+  ) {
+
+    getUserFromPrincipal(principal);
+    Conti conti = contiService.getContiById(contiId);
+    ContiResponse response = mapToContiResponse(conti);
+
+    return ResponseEntity.ok(response);
+  }
+
+  private User getUserFromPrincipal(Principal principal) {
+    if (principal == null) {
+      throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
+    }
+
+    return userRepository.findByEmail(principal.getName())
+        .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+  }
+
+  private ContiParseResponse mapToParseResponse(Conti conti) {
+    List<ContiParseResponse.SongDto> songDtos = conti.getSongs().stream()
+        .map(song -> ContiParseResponse.SongDto.builder()
+            .title(song.getTitle())
+            .originalKey(song.getOriginalKey())
+            .performanceKey(song.getPerformanceKey())
+            .youtubeUrl(song.getYoutubeUrl())
+            .specialInstructions(song.getSpecialInstructions())
+            .bpm(song.getBpm())
+            .build())
+        .toList();
+
+    return ContiParseResponse.builder()
+        .title(conti.getTitle())
+        .scheduledAt(conti.getScheduledAt())
+        .songs(songDtos)
+        .version(conti.getVersion())
+        .status(conti.getStatus().name())
+        .build();
+  }
+
+  private ContiResponse mapToContiResponse(Conti conti) {
+    return ContiResponse.builder()
+        .id(conti.getId())
+        .title(conti.getTitle())
+        .description(conti.getDescription())
+        .scheduledAt(conti.getScheduledAt())
+        .creatorId(conti.getCreator() != null ? conti.getCreator().getId() : null)
+        .creatorName(conti.getCreator() != null ? conti.getCreator().getName() : null)
+        .songs(conti.getSongs().stream()
+            .map(song -> ContiResponse.SongDto.builder()
+                .id(song.getId())
+                .title(song.getTitle())
+                .originalKey(song.getOriginalKey())
+                .performanceKey(song.getPerformanceKey())
+                .artist(song.getArtist())
+                .youtubeUrl(song.getYoutubeUrl())
+                .specialInstructions(song.getSpecialInstructions())
+                .build())
+            .collect(Collectors.toList()))
+        .status(conti.getStatus().name())
+        .createdAt(conti.getCreatedAt())
+        .updatedAt(conti.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
@@ -59,13 +59,13 @@ public class ContiParserService {
       title = extractTitle(lines);
     }
 
-    LocalDate performanceDate = extractDate(contiText);
+    LocalDate scheduledAt = extractDate(contiText);
 
     List<Song> songs = extractSongs(contiText);
 
     Conti conti = Conti.builder()
         .title(title)
-        .scheduledAt(performanceDate != null ? performanceDate : LocalDate.now())
+        .scheduledAt(scheduledAt != null ? scheduledAt : LocalDate.now())
         .creator(creator)
         .songs(songs)
         .version("1.0")

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiRepository.java
@@ -1,8 +1,12 @@
 package faithcoderlab.newdpraise.domain.conti;
 
+import faithcoderlab.newdpraise.domain.user.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContiRepository extends JpaRepository<Conti, Long> {
+
+  List<Conti> findByCreatorOrderByScheduledAtDesc(User creator);
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiService.java
@@ -1,0 +1,83 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import faithcoderlab.newdpraise.domain.conti.dto.ContiCreateRequest;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.song.SongRepository;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContiService {
+
+  private final ContiRepository contiRepository;
+  private final SongRepository songRepository;
+  private final ContiParserService contiParserService;
+
+  @Transactional
+  public Conti createConti(ContiCreateRequest request, User creator) {
+    Conti conti;
+
+    if (request.getContiText() != null && !request.getContiText().isEmpty()) {
+      conti = contiParserService.parseContiText(request.getContiText(), creator);
+    } else {
+      conti = Conti.builder()
+          .title(request.getTitle())
+          .description(request.getDescription())
+          .scheduledAt(request.getScheduledAt())
+          .creator(creator)
+          .version("1.0")
+          .status(ContiStatus.DRAFT)
+          .build();
+
+      if (request.getSongs() != null) {
+        List<Song> songs = request.getSongs().stream()
+            .map(songDto -> Song.builder()
+                .title(songDto.getTitle())
+                .originalKey(songDto.getOriginalKey())
+                .performanceKey(songDto.getPerformanceKey())
+                .artist(songDto.getArtist())
+                .youtubeUrl(songDto.getYoutubeUrl())
+                .referenceUrl(songDto.getReferenceUrl())
+                .specialInstructions(songDto.getSpecialInstructions())
+                .bpm(songDto.getBpm())
+                .build())
+            .collect(Collectors.toList());
+
+        songs = songRepository.saveAll(songs);
+        conti.setSongs(songs);
+      }
+    }
+
+    return contiRepository.save(conti);
+  }
+
+  @Transactional(readOnly = true)
+  public List<Conti> getUserContiList(User user) {
+    return contiRepository.findByCreatorOrderByScheduledAtDesc(user);
+  }
+
+  @Transactional(readOnly = true)
+  public Conti getContiById(Long contiId) {
+    return contiRepository.findById(contiId)
+        .orElseThrow(() -> new ResourceNotFoundException("콘티를 찾을 수 없습니다. ID: " + contiId));
+  }
+
+  @Transactional
+  public void updateContiStatus(Long contiId, ContiStatus status) {
+    Conti conti = getContiById(contiId);
+    conti.setStatus(status);
+    contiRepository.save(conti);
+  }
+
+  @Transactional
+  public void deleteConti(Long contiId) {
+    Conti conti = getContiById(contiId);
+    contiRepository.delete(conti);
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiCreateRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiCreateRequest.java
@@ -1,5 +1,6 @@
 package faithcoderlab.newdpraise.domain.conti.dto;
 
+import faithcoderlab.newdpraise.domain.conti.dto.ContiParseResponse.SongDto;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -11,12 +12,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ContiParseResponse {
+public class ContiCreateRequest {
   private String title;
+  private String description;
   private LocalDate scheduledAt;
+  private String contiText;
   private List<SongDto> songs;
-  private String version;
-  private String status;
 
   @Data
   @Builder
@@ -26,7 +27,9 @@ public class ContiParseResponse {
     private String title;
     private String originalKey;
     private String performanceKey;
+    private String artist;
     private String youtubeUrl;
+    private String referenceUrl;
     private String specialInstructions;
     private String bpm;
   }

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiResponse.java
@@ -1,6 +1,7 @@
 package faithcoderlab.newdpraise.domain.conti.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,23 +12,29 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ContiParseResponse {
+public class ContiResponse {
+  private Long id;
   private String title;
+  private String description;
   private LocalDate scheduledAt;
+  private Long creatorId;
+  private String creatorName;
   private List<SongDto> songs;
-  private String version;
   private String status;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 
   @Data
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
   public static class SongDto {
+    private Long id;
     private String title;
     private String originalKey;
     private String performanceKey;
+    private String artist;
     private String youtubeUrl;
     private String specialInstructions;
-    private String bpm;
   }
 }

--- a/src/main/java/faithcoderlab/newdpraise/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/exception/GlobalExceptionHandler.java
@@ -108,4 +108,23 @@ public class GlobalExceptionHandler {
     );
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
   }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+    if (ex.getMessage().contains("인증되지 않은 사용자입니다.")) {
+      ErrorResponse errorResponse = new ErrorResponse(
+          HttpStatus.UNAUTHORIZED.value(),
+          ex.getMessage(),
+          LocalDateTime.now()
+      );
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    ErrorResponse errorResponse = new ErrorResponse(
+        HttpStatus.BAD_REQUEST.value(),
+        ex.getMessage(),
+        LocalDateTime.now()
+    );
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
 }

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiControllerTest.java
@@ -1,0 +1,207 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiParseRequest;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestConfig.class, TestSecurityConfig.class})
+class ContiControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ContiService contiService;
+
+  @MockBean
+  private ContiParserService contiParserService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  private User testUser;
+  private Conti testConti;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("테스트 콘티")
+        .scheduledAt(LocalDate.now())
+        .creator(testUser)
+        .version("1.0")
+        .status(ContiStatus.DRAFT)
+        .songs(new ArrayList<>())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("콘티 텍스트 파싱 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void parseContiTextSuccess() throws Exception {
+    // given
+    ContiParseRequest request = new ContiParseRequest("20250405 찬양집회 콘티\n1. 물댄 동산 G");
+    List<Song> songs = Collections.singletonList(
+        Song.builder()
+            .title("물댄 동산")
+            .performanceKey("G")
+            .build()
+    );
+
+    Conti parsedConti = Conti.builder()
+        .title("20250405 찬양집회 콘티")
+        .scheduledAt(LocalDate.of(2025, 4, 5))
+        .songs(songs)
+        .version("1.0")
+        .status(ContiStatus.DRAFT)
+        .build();
+
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
+    when(contiParserService.parseContiText(anyString(), any(User.class))).thenReturn(parsedConti);
+
+    // when & then
+    mockMvc.perform(post("/conti/parse")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("20250405 찬양집회 콘티"))
+        .andExpect(jsonPath("$.songs[0].title").value("물댄 동산"))
+        .andExpect(jsonPath("$.songs[0].performanceKey").value("G"));
+  }
+
+  @Test
+  @DisplayName("콘티 생성 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void createContiSuccess() throws Exception {
+    // given
+    ContiCreateRequest request = ContiCreateRequest.builder()
+        .title("새 콘티")
+        .description("테스트 콘티 설명")
+        .scheduledAt(LocalDate.now())
+        .songs(Collections.singletonList(
+            ContiCreateRequest.SongDto.builder()
+                .title("테스트 곡")
+                .originalKey("C")
+                .performanceKey("D")
+                .artist("테스트 아티스트")
+                .youtubeUrl("https://youtube.com/watch?v=test123")
+                .build()
+        ))
+        .build();
+
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
+    when(contiService.createConti(any(ContiCreateRequest.class), any(User.class)))
+        .thenReturn(testConti);
+
+    // when & then
+    mockMvc.perform(post("/conti")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("테스트 콘티"));
+  }
+
+  @Test
+  @DisplayName("콘티 목록 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getContiListSuccess() throws Exception {
+    // given
+    List<Conti> contiList = Collections.singletonList(testConti);
+
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
+    when(contiService.getUserContiList(any(User.class))).thenReturn(contiList);
+
+    // when & then
+    mockMvc.perform(get("/conti"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].title").value("테스트 콘티"));
+  }
+
+  @Test
+  @DisplayName("콘티 상세 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getContiDetailSuccess() throws Exception {
+    // given
+    when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
+    when(contiService.getContiById(anyLong())).thenReturn(testConti);
+
+    // when & then
+    mockMvc.perform(get("/conti/{contiId}", 1L))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("테스트 콘티"));
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자 요청 - 실패")
+  void unauthorizedRequest() throws Exception {
+    // given
+    ContiParseRequest request = new ContiParseRequest("테스트 콘티");
+
+    // when & then
+    mockMvc.perform(post("/conti/parse")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.message").value("인증되지 않은 사용자입니다."));
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiServiceTest.java
@@ -1,0 +1,200 @@
+package faithcoderlab.newdpraise.domain.conti;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import faithcoderlab.newdpraise.domain.conti.dto.ContiCreateRequest;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.song.SongRepository;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContiServiceTest {
+
+  @Mock
+  private ContiRepository contiRepository;
+
+  @Mock
+  private SongRepository songRepository;
+
+  @Mock
+  private ContiParserService contiParserService;
+
+  @InjectMocks
+  private ContiService contiService;
+
+  private User testUser;
+  private Conti testConti;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("테스트 콘티")
+        .scheduledAt(LocalDate.now())
+        .creator(testUser)
+        .version("1.0")
+        .status(ContiStatus.DRAFT)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("콘티 생성 - 텍스트 형태")
+  void createContiFromText() {
+    // given
+    ContiCreateRequest request = ContiCreateRequest.builder()
+        .contiText("20250405 찬양집회 콘티\n1. 물댄 동산 G")
+        .build();
+
+    when(contiParserService.parseContiText(anyString(), any(User.class)))
+        .thenReturn(testConti);
+    when(contiRepository.save(any(Conti.class))).thenReturn(testConti);
+
+    // when
+    Conti result = contiService.createConti(request, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+    verify(contiParserService).parseContiText(request.getContiText(), testUser);
+    verify(contiRepository).save(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("콘티 생성 - 구조화된 데이터")
+  void createContiFromStructuredData() {
+    // given
+    List<ContiCreateRequest.SongDto> songDtos = Collections.singletonList(
+        ContiCreateRequest.SongDto.builder()
+            .title("테스트 곡")
+            .originalKey("C")
+            .performanceKey("D")
+            .build()
+    );
+
+    ContiCreateRequest request = ContiCreateRequest.builder()
+        .title("새 콘티")
+        .description("테스트 설명")
+        .scheduledAt(LocalDate.now())
+        .songs(songDtos)
+        .build();
+
+    List<Song> savedSongs = Collections.singletonList(
+        Song.builder()
+            .id(1L)
+            .title("테스트 곡")
+            .originalKey("C")
+            .performanceKey("D")
+            .build()
+    );
+
+    when(songRepository.saveAll(anyList())).thenReturn(savedSongs);
+    when(contiRepository.save(any(Conti.class))).thenReturn(testConti);
+
+    // when
+    Conti result = contiService.createConti(request, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(songRepository).saveAll(anyList());
+    verify(contiRepository).save(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("사용자 콘티 목록 조회")
+  void getUserContiList() {
+    // given
+    List<Conti> contiList = Collections.singletonList(testConti);
+    when(contiRepository.findByCreatorOrderByScheduledAtDesc(testUser))
+        .thenReturn(contiList);
+
+    // when
+    List<Conti> result = contiService.getUserContiList(testUser);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("콘티 ID로 조회 - 성공")
+  void getContiByIdSuccess() {
+    // given
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+
+    // when
+    Conti result = contiService.getContiById(1L);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("콘티 ID로 조회 - 실패")
+  void getContiByIdNotFound() {
+    // given
+    when(contiRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiService.getContiById(999L))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("콘티를 찾을 수 없습니다");
+  }
+
+  @Test
+  @DisplayName("콘티 상태 업데이트")
+  void updateContiStatus() {
+    // given
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(contiRepository.save(any(Conti.class))).thenReturn(testConti);
+
+    // when
+    contiService.updateContiStatus(1L, ContiStatus.FINALIZED);
+
+    // then
+    verify(contiRepository).save(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("콘티 삭제")
+  void deleteConti() {
+    // given
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+
+    // when
+    contiService.deleteConti(1L);
+
+    // then
+    verify(contiRepository).delete(testConti);
+  }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -24,3 +24,17 @@ CREATE TABLE refresh_tokens (
     expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP NOT NULL
 );
+
+CREATE TABLE conti (
+   id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   title VARCHAR(255),
+   description TEXT,
+   scheduled_at DATE NOT NULL,
+   creator_id BIGINT,
+   version VARCHAR(50) NOT NULL,
+   original_text TEXT,
+   status VARCHAR(20) NOT NULL,
+   created_at TIMESTAMP NOT NULL,
+   updated_at TIMESTAMP,
+   FOREIGN KEY (creator_id) REFERENCES users(id)
+);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 콘티 관리 기능 부재
- 텍스트 형태의 콘티를 파싱하는 기능 없음

**TO-BE**
- 콘티 텍스트 파싱 API 추가
- 콘티 CRUD API 구현
- 구조화된 콘티 데이터 관리 기능 추가

### 구현 기능
#### 1. 콘티 텍스트 파싱 API (`POST /conti/parse`)
- 텍스트 형태의 콘티를 구조화된 데이터로 파싱
- 날짜, 곡 정보, 키, 유튜브 URL 등 자동 추출

#### 2. 콘티 생성 API (`POST /conti`)
- 텍스트 형태 또는 구조화된 데이터로 콘티 생성 가능
- 곡 정보 자동 저장

#### 3. 콘티 조회 API
- 콘티 목록 조회 (`GET /conti`)
- 콘티 상세 조회 (`GET /conti/{contiId}`)

### 주요 변경 파일
- `ContiController.java`: 콘티 관련 엔드포인트 구현
- `ContiService.java`: 콘티 비즈니스 로직 처리
- `ContiParserService.java`: 텍스트 파싱 로직 구현
- `ContiRepository.java`: 데이터 접근 계층
- 관련 DTO 클래스들

### 데이터베이스 변경사항
- `performance_date` 컬럼 → `scheduled_at`으로 이름 변경
- 기존 데이터 마이그레이션 완료

### 테스트 결과
#### ContiControllerTest.java
<img width="370" alt="스크린샷 2025-04-22 오후 5 42 51" src="https://github.com/user-attachments/assets/2d7d48d7-00c2-432a-abd1-c93895c50f98" />

#### ContiServiceTest.java
<img width="376" alt="스크린샷 2025-04-22 오후 5 43 39" src="https://github.com/user-attachments/assets/a2b3cd0d-db76-4114-b12a-88ae5076ef7c" />

#### Swagger UI 테스트
<img width="1065" alt="스크린샷 2025-04-22 오후 5 25 46" src="https://github.com/user-attachments/assets/34e21948-1734-4161-961f-848d2adffc4b" />
<img width="1053" alt="스크린샷 2025-04-22 오후 5 36 01" src="https://github.com/user-attachments/assets/429596dd-376c-4860-a653-f75faf4a532e" />

### 테스트
- [x] 테스트 코드
  - `ContiControllerTest`: 컨트롤러 단위 테스트
  - `ContiServiceTest`: 서비스 계층 테스트
  - `ContiParserServiceTest`: 파서 로직 테스트 (이전 PR 에서 작성)
- [x] API 테스트 