### PR TITLE
refactor: SongAnalysisService 코드 품질 및 테스트 개선

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
@@ -2,6 +2,7 @@ package faithcoderlab.newdpraise.domain.conti;
 
 import faithcoderlab.newdpraise.domain.song.Song;
 import faithcoderlab.newdpraise.domain.song.SongRepository;
+import faithcoderlab.newdpraise.domain.song.UrlType;
 import faithcoderlab.newdpraise.domain.user.User;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -202,13 +203,13 @@ public class ContiParserService {
           url = extractUrl(songLine);
         }
 
-        String urlType = getUrlType(url);
+        UrlType urlType = UrlType.fromUrl(url);
 
         String youtubeUrl = null;
         String referenceUrl = null;
 
         if (url != null) {
-          if ("youtube".equals(urlType)) {
+          if (urlType == UrlType.YOUTUBE) {
             youtubeUrl = url;
           } else {
             referenceUrl = url;
@@ -221,9 +222,6 @@ public class ContiParserService {
         );
 
         String bpm = extractBpm(additionalInfo.toString());
-        if (bpm == null) {
-          bpm = extractBpm(songLine);
-        }
 
         if (!title.isEmpty()) {
           Song song = Song.builder()
@@ -233,15 +231,13 @@ public class ContiParserService {
               .artist(artist)
               .youtubeUrl(youtubeUrl)
               .referenceUrl(referenceUrl)
-              .urlType(urlType)
+              .urlType(urlType != null ? urlType.getValue() : null)
               .specialInstructions(specialInstructions)
               .bpm(bpm)
               .build();
 
           songs.add(song);
         }
-      } else if (!foundSongLine) {
-        continue;
       }
     }
 
@@ -340,16 +336,8 @@ public class ContiParserService {
     return null;
   }
 
-  private String getUrlType(String url) {
-    if (url == null) {
-      return null;
-    }
-
-    if (url.contains("youtube.com") || url.contains("youtu.be")) {
-      return "youtube";
-    } else {
-      return "other";
-    }
+  private UrlType determineUrlType(String url) {
+    return UrlType.fromUrl(url);
   }
 
   private String extractBpm(String text) {

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/ContiParserService.java
@@ -231,7 +231,7 @@ public class ContiParserService {
               .artist(artist)
               .youtubeUrl(youtubeUrl)
               .referenceUrl(referenceUrl)
-              .urlType(urlType != null ? urlType.getValue() : null)
+              .urlType(urlType)
               .specialInstructions(specialInstructions)
               .bpm(bpm)
               .build();

--- a/src/main/java/faithcoderlab/newdpraise/domain/song/PitchDistribution.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/song/PitchDistribution.java
@@ -1,0 +1,53 @@
+package faithcoderlab.newdpraise.domain.song;
+
+public class PitchDistribution {
+  private static final int PITCH_CLASSES = 12;
+  private final int[] distribution;
+
+  public PitchDistribution() {
+    this.distribution = new int[PITCH_CLASSES];
+  }
+
+  public void addPitchClass(int pitchClass) {
+    if (pitchClass >= 0 && pitchClass < PITCH_CLASSES) {
+      distribution[pitchClass]++;
+    }
+  }
+
+  public int getDominantPitchClass() {
+    int maxCount = -1;
+    int dominantPitchClass = 0;
+
+    for (int i = 0; i < PITCH_CLASSES; i++) {
+      if (distribution[i] > maxCount) {
+        maxCount = distribution[i];
+        dominantPitchClass = i;
+      }
+    }
+
+    return dominantPitchClass;
+  }
+
+  public boolean isMajor() {
+    int dominantPitchClass = getDominantPitchClass();
+    int majorThirdIndex = (dominantPitchClass + 4) % PITCH_CLASSES;
+    int minorThirdIndex = (dominantPitchClass + 3) % PITCH_CLASSES;
+
+    return distribution[majorThirdIndex] > distribution[minorThirdIndex];
+  }
+
+  public int getCount(int pitchClass) {
+    if (pitchClass >= 0 && pitchClass < PITCH_CLASSES) {
+      return distribution[pitchClass];
+    }
+    return 0;
+  }
+
+  public boolean hasEnoughData() {
+    int totalCount = 0;
+    for (int count : distribution) {
+      totalCount += count;
+    }
+    return totalCount >= 100;
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/song/Song.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/song/Song.java
@@ -2,6 +2,8 @@ package faithcoderlab.newdpraise.domain.song;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -40,7 +42,8 @@ public class Song {
 
   private String referenceUrl;
 
-  private String urlType;
+  @Enumerated(EnumType.STRING)
+  private UrlType urlType;
 
   private Integer durationSeconds;
 

--- a/src/main/java/faithcoderlab/newdpraise/domain/song/Song.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/song/Song.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Table(name = "songs")
@@ -66,10 +67,6 @@ public class Song {
   }
 
   public String getUrl() {
-    if (youtubeUrl != null && !youtubeUrl.isEmpty()) {
-      return youtubeUrl;
-    } else {
-      return referenceUrl;
-    }
+    return StringUtils.hasText(youtubeUrl) ? youtubeUrl : referenceUrl;
   }
 }

--- a/src/main/java/faithcoderlab/newdpraise/domain/song/SongAnalysisService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/song/SongAnalysisService.java
@@ -123,6 +123,8 @@ public class SongAnalysisService {
       }
 
       return downloadedFile;
+    } catch (SongAnalysisException e) {
+      throw e;
     } catch (Exception e) {
       throw new SongAnalysisException("예기치 않은 오류 발생: " + videoId, e);
     }

--- a/src/main/java/faithcoderlab/newdpraise/domain/song/UrlType.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/song/UrlType.java
@@ -1,0 +1,28 @@
+package faithcoderlab.newdpraise.domain.song;
+
+public enum UrlType {
+  YOUTUBE("youtube"),
+  OTHER("other");
+
+  private final String value;
+
+  UrlType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static UrlType fromUrl(String url) {
+    if (url == null) {
+      return null;
+    }
+
+    if (url.contains("youtube.com") || url.contains("youtu.be")) {
+      return YOUTUBE;
+    }
+
+    return OTHER;
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/global/exception/SongAnalysisException.java
+++ b/src/main/java/faithcoderlab/newdpraise/global/exception/SongAnalysisException.java
@@ -1,0 +1,12 @@
+package faithcoderlab.newdpraise.global.exception;
+
+public class SongAnalysisException extends RuntimeException {
+
+  public SongAnalysisException(String message) {
+    super(message);
+  }
+
+  public SongAnalysisException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- SongAnalysisService에서 에러 상황을 `log.error()` + `null` 반환으로 처리
- URL 타입이 String으로 관리되어 타입 안전성이 떨어짐
- 불필요한 매직 넘버 사용
- 테스트 코드에서 불필요한 lenient() 사용

**TO-BE**
- null 반환 대신 SongAnalysisException을 사용한 명확한 예외 처리
- URL 타입을 Enum으로 관리
- 매직 넘버를 명확한 상수로 추출
- PtichDistribution 클래스 분리
- 테스트 코드 개선 및 불필요한 mock 제거

### 테스트
- [x] 테스트 코드
- [x] API 테스트 

### 관련 이슈
#18 [리팩토링] SongAnalysisService 예외 처리 방식 개선 
#19 [리팩토링] URL Type을 Enum으로 개선
#20 [리팩토링] PitchDistribution 클래스 분리