### PR TITLE
feat: 콘티 공유 기능 구현

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/dto/ContiResponse.java
@@ -23,6 +23,10 @@ public class ContiResponse {
   private String status;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private boolean isShared;
+  private boolean canEdit;
+  private boolean canShare;
+  private String permissionType;
 
   @Data
   @Builder

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShare.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShare.java
@@ -1,0 +1,81 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "conti_shares", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"conti_id", "user_id"})
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiShare {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "conti_id", nullable = false)
+  private Conti conti;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "shared_by")
+  private User sharedBy;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ContiSharePermission permission;
+
+  @Column(nullable = false)
+  private boolean accepted;
+
+  @Column(name = "invited_at", nullable = false)
+  private LocalDateTime invitedAt;
+
+  @Column(name = "accepted_at")
+  private LocalDateTime acceptedAt;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+    updatedAt = LocalDateTime.now();
+    invitedAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareController.java
@@ -1,0 +1,187 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareRequest;
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareResponse;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/conti/shares")
+@RequiredArgsConstructor
+@Tag(name = "ContiShare", description = "콘티 공유 관련 API")
+public class ContiShareController {
+
+  private final ContiShareService contiShareService;
+  private final UserRepository userRepository;
+
+  @Operation(summary = "콘티 공유 초대 생성", description = "다른 사용자에게 콘티를 공유합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "공유 초대 생성 성공",
+          content = @Content(schema = @Schema(implementation = ContiShareResponse.class))),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "공유 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "콘티 또는 사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "409", description = "이미 공유된 콘티")
+  })
+  @PostMapping
+  public ResponseEntity<ContiShareResponse> createShare(
+      @Valid @RequestBody ContiShareRequest request,
+      Principal principal
+  ) {
+    User currentUser = getUserFromPrincipal(principal);
+    ContiShare contiShare = contiShareService.createShare(request, currentUser);
+    ContiShareResponse response = ContiShareResponse.fromContiShare(contiShare);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "콘티 공유 초대 수락", description = "공유 초대를 수락합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "공유 초대 수락 성공",
+          content = @Content(schema = @Schema(implementation = ContiShareResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "수락 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "공유 정보를 찾을 수 없음"),
+      @ApiResponse(responseCode = "409", description = "이미 수락된 공유 요청")
+  })
+  @PostMapping("/{shareId}/accept")
+  public ResponseEntity<ContiShareResponse> acceptShare(
+      @PathVariable Long shareId,
+      Principal principal
+  ) {
+    User currentUser = getUserFromPrincipal(principal);
+    ContiShare contiShare = contiShareService.acceptShare(shareId, currentUser);
+    ContiShareResponse response = ContiShareResponse.fromContiShare(contiShare);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "콘티 공유 삭제", description = "공유 초대를 거절하거나 기존 공유를 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "공유 삭제 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "공유 정보를 찾을 수 없음")
+  })
+  @DeleteMapping("/{shareId}")
+  public ResponseEntity<Void> deleteShare(
+      @PathVariable Long shareId,
+      Principal principal
+  ) {
+    User currentUser = getUserFromPrincipal(principal);
+    contiShareService.deleteShare(shareId, currentUser);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "콘티 공유 권한 수정", description = "공유된 콘티의 권한을 수정합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "권한 수정 성공",
+          content = @Content(schema = @Schema(implementation = ContiShareResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "권한 수정 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "공유 정보를 찾을 수 없음")
+  })
+  @PutMapping("/{shareId}/permission")
+  public ResponseEntity<ContiShareResponse> updatePermission(
+      @PathVariable Long shareId,
+      @RequestParam ContiSharePermission permission,
+      Principal principal
+  ) {
+    User currentUser = getUserFromPrincipal(principal);
+    ContiShare contiShare = contiShareService.updateSharePermission(shareId, permission, currentUser);
+    ContiShareResponse response = ContiShareResponse.fromContiShare(contiShare);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "내게 공유된 콘티 목록 조회", description = "현재 사용자에게 공유된 콘티 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/shared-with-me")
+  public ResponseEntity<List<ContiShareResponse>> getSharedWithMe(Principal principal) {
+    User currentUser = getUserFromPrincipal(principal);
+    List<ContiShare> shares = contiShareService.getSharedContis(currentUser);
+
+    List<ContiShareResponse> responses = shares.stream()
+        .map(ContiShareResponse::fromContiShare)
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "내게 온 공유 요청 목록 조회", description = "현재 사용자에게 온 미수락 공유 요청 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/pending")
+  public ResponseEntity<List<ContiShareResponse>> getPendingShares(Principal principal) {
+    User currentUser = getUserFromPrincipal(principal);
+    List<ContiShare> shares = contiShareService.getPendingShares(currentUser);
+
+    List<ContiShareResponse> responses = shares.stream()
+        .map(ContiShareResponse::fromContiShare)
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "콘티 공유 목록 조회", description = "특정 콘티의 공유 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "조회 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "콘티를 찾을 수 없음")
+  })
+  @GetMapping("/conti/{contiId}")
+  public ResponseEntity<List<ContiShareResponse>> getContiShares(
+      @PathVariable Long contiId,
+      Principal principal
+  ) {
+    User currentUser = getUserFromPrincipal(principal);
+    List<ContiShare> shares = contiShareService.getContiShares(contiId, currentUser);
+
+    List<ContiShareResponse> responses = shares.stream()
+        .map(ContiShareResponse::fromContiShare)
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  private User getUserFromPrincipal(Principal principal) {
+    if (principal == null) {
+      throw new AuthenticationException("인증되지 않은 사용자입니다.");
+    }
+
+    return userRepository.findByEmail(principal.getName())
+        .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiSharePermission.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiSharePermission.java
@@ -1,0 +1,7 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+public enum ContiSharePermission {
+  VIEW,
+  EDIT,
+  ADMIN
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareRepository.java
@@ -1,0 +1,37 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.user.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContiShareRepository extends JpaRepository<ContiShare, Long> {
+
+  List<ContiShare> findByUser(User user);
+
+  List<ContiShare> findByUserAndAcceptedTrue(User user);
+
+  List<ContiShare> findByUserAndAcceptedFalse(User user);
+
+  List<ContiShare> findByConti(Conti conti);
+
+  Optional<ContiShare> findByContiAndUser(Conti conti, User user);
+
+  @Query("SELECT cs FROM ContiShare cs WHERE cs.conti.id = :contiId AND cs.user.id = :userId")
+  Optional<ContiShare> findByContiIdAndUserId(@Param("contiId") Long contiId, @Param("userId") Long userId);
+
+  @Query("SELECT cs FROM ContiShare cs WHERE cs.conti.id = :contiId AND cs.user.id = :userId AND cs.accepted = true")
+  Optional<ContiShare> findAcceptedShareByContiIdAndUserId(@Param("contiId") Long contiId, @Param("userId") Long userId);
+
+  @Query("SELECT COUNT(cs) > 0 FROM ContiShare cs WHERE cs.conti.id = :contiId AND cs.user.id = :userId AND cs.permission IN :permissions AND cs.accepted = true")
+  boolean hasPermission(@Param("contiId") Long contiId, @Param("userId") Long userId, @Param("permissions") List<ContiSharePermission> permissions);
+
+  void deleteByConti(Conti conti);
+
+  void deleteByContiAndUser(Conti conti, User user);
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareService.java
@@ -1,0 +1,162 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiRepository;
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareRequest;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceAlreadyExistsException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContiShareService {
+
+  private final ContiShareRepository contiShareRepository;
+  private final ContiRepository contiRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public ContiShare createShare(ContiShareRequest request, User currentUser) {
+    Conti conti = contiRepository.findById(request.getContiId())
+        .orElseThrow(
+            () -> new ResourceNotFoundException("콘티를 찾을 수 없습니다. ID: " + request.getContiId()));
+
+    validateSharePermission(conti, currentUser);
+
+    User targetUser = userRepository.findByEmail(request.getUserEmail())
+        .orElseThrow(() -> new ResourceNotFoundException(
+            "사용자를 찾을 수 없습니다.: Email: " + request.getUserEmail()));
+
+    if (targetUser.getId().equals(currentUser.getId())) {
+      throw new IllegalArgumentException("자신에게는 콘티를 공유할 수 없습니다.");
+    }
+
+    contiShareRepository.findByContiAndUser(conti, targetUser).ifPresent(share -> {
+      throw new ResourceAlreadyExistsException("이미 해당 사용자에게 공유된 콘티입니다.");
+    });
+
+    ContiShare contiShare = ContiShare.builder()
+        .conti(conti)
+        .user(targetUser)
+        .sharedBy(currentUser)
+        .permission(request.getPermission())
+        .accepted(false)
+        .build();
+
+    return contiShareRepository.save(contiShare);
+  }
+
+  @Transactional
+  public ContiShare acceptShare(Long shareId, User currentUser) {
+    ContiShare share = contiShareRepository.findById(shareId)
+        .orElseThrow(() -> new ResourceNotFoundException("공유 정보를 찾을 수 없습니다. ID: " + shareId));
+
+    if (!share.getUser().getId().equals(currentUser.getId())) {
+      throw new AuthenticationException("해당 공유 요청에 대한 권한이 없습니다.");
+    }
+
+    if (share.isAccepted()) {
+      throw new ResourceAlreadyExistsException("이미 수락된 공유 요청입니다.");
+    }
+
+    share.setAccepted(true);
+    share.setAcceptedAt(LocalDateTime.now());
+
+    return contiShareRepository.save(share);
+  }
+
+  @Transactional
+  public void deleteShare(Long shareId, User currentUser) {
+    ContiShare share = contiShareRepository.findById(shareId)
+        .orElseThrow(() -> new ResourceNotFoundException("공유 정보를 찾을 수 없습니다. ID: " + shareId));
+
+    if (!share.getUser().getId().equals(currentUser.getId()) &&
+        (share.getSharedBy() == null || !share.getSharedBy().getId().equals(currentUser.getId())) &&
+        !share.getConti().getCreator().getId().equals(currentUser.getId())) {
+      throw new AuthenticationException("해당 공유 요청을 삭제할 권한이 없습니다.");
+    }
+
+    contiShareRepository.delete(share);
+  }
+
+  @Transactional
+  public ContiShare updateSharePermission(Long shareId, ContiSharePermission permission,
+      User currentUser) {
+    ContiShare share = contiShareRepository.findById(shareId)
+        .orElseThrow(() -> new ResourceNotFoundException("공유 정보를 찾을 수 없습니다. ID: " + shareId));
+
+    if ((share.getSharedBy() == null || !share.getSharedBy().getId().equals(currentUser.getId())) &&
+        !share.getConti().getCreator().getId().equals(currentUser.getId())) {
+      throw new AuthenticationException("해당 공유 요청의 권한을 수정할 권한이 없습니다.");
+    }
+
+    share.setPermission(permission);
+
+    return contiShareRepository.save(share);
+  }
+
+  public List<ContiShare> getSharedContis(User user) {
+    return contiShareRepository.findByUserAndAcceptedTrue(user);
+  }
+
+  public List<ContiShare> getPendingShares(User user) {
+    return contiShareRepository.findByUserAndAcceptedFalse(user);
+  }
+
+  public List<ContiShare> getContiShares(Long contiId, User currentUser) {
+    Conti conti = contiRepository.findById(contiId)
+        .orElseThrow(() -> new ResourceNotFoundException("콘티를 찾을 수 없습니다. ID: " + contiId));
+
+    validateSharePermission(conti, currentUser);
+
+    return contiShareRepository.findByConti(conti);
+  }
+
+  public boolean hasPermission(Long contiId, Long userId, ContiSharePermission... permissions) {
+    return contiShareRepository.hasPermission(contiId, userId, Arrays.asList(permissions));
+  }
+
+  private void validateSharePermission(Conti conti, User user) {
+    boolean isCreator = conti.getCreator() != null && conti.getCreator().getId().equals(user.getId());
+    boolean hasAdminPermission = contiShareRepository.hasPermission(
+        conti.getId(), user.getId(), List.of(ContiSharePermission.ADMIN)
+    );
+
+    if (!isCreator && !hasAdminPermission) {
+      throw new AuthenticationException("콘티를 공유할 권한이 없습니다.");
+    }
+  }
+
+  public boolean canEditConti(Conti conti, User user) {
+    if (conti.getCreator() != null && conti.getCreator().getId().equals(user.getId())) {
+      return true;
+    }
+
+    return contiShareRepository.hasPermission(
+        conti.getId(),
+        user.getId(),
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT)
+    );
+  }
+
+  public boolean canViewConti(Conti conti, User user) {
+    if (conti.getCreator() != null && conti.getCreator().getId().equals(user.getId())) {
+      return true;
+    }
+
+    return contiShareRepository.hasPermission(
+        conti.getId(),
+        user.getId(),
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT, ContiSharePermission.VIEW)
+    );
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/dto/ContiShareRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/dto/ContiShareRequest.java
@@ -1,0 +1,27 @@
+package faithcoderlab.newdpraise.domain.conti.share.dto;
+
+import faithcoderlab.newdpraise.domain.conti.share.ContiSharePermission;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiShareRequest {
+
+  @NotNull(message = "콘티 ID는 필수 입력 항목입니다.")
+  private Long contiId;
+
+  @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+  @Email(message = "유효한 이메일 형식이 아닙니다.")
+  private String userEmail;
+
+  @NotNull(message = "권한은 필수 입력 항목입니다.")
+  private ContiSharePermission permission;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/share/dto/ContiShareResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/share/dto/ContiShareResponse.java
@@ -1,0 +1,46 @@
+package faithcoderlab.newdpraise.domain.conti.share.dto;
+
+import faithcoderlab.newdpraise.domain.conti.share.ContiShare;
+import faithcoderlab.newdpraise.domain.conti.share.ContiSharePermission;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiShareResponse {
+
+  private Long id;
+  private Long contiId;
+  private String contiTitle;
+  private Long userId;
+  private String userEmail;
+  private String userName;
+  private Long sharedById;
+  private String sharedByName;
+  private ContiSharePermission permission;
+  private boolean accepted;
+  private LocalDateTime invitedAt;
+  private LocalDateTime acceptedAt;
+
+  public static ContiShareResponse fromContiShare(ContiShare contiShare) {
+    return ContiShareResponse.builder()
+        .id(contiShare.getId())
+        .contiId(contiShare.getConti().getId())
+        .contiTitle(contiShare.getConti().getTitle())
+        .userId(contiShare.getUser().getId())
+        .userEmail(contiShare.getUser().getEmail())
+        .userName(contiShare.getUser().getName())
+        .sharedById(contiShare.getSharedBy() != null ? contiShare.getSharedBy().getId() : null)
+        .sharedByName(contiShare.getSharedBy() != null ? contiShare.getSharedBy().getName() : null)
+        .permission(contiShare.getPermission())
+        .accepted(contiShare.isAccepted())
+        .invitedAt(contiShare.getInvitedAt())
+        .acceptedAt(contiShare.getAcceptedAt())
+        .build();
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiControllerTest.java
@@ -365,7 +365,7 @@ class ContiControllerTest {
 
     when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
     when(contiService.getContiByIdAndCreator(anyLong(), any(User.class))).thenReturn(updatedConti);
-    doNothing().when(contiService).updateContiStatus(anyLong(), any(ContiStatus.class));
+    doNothing().when(contiService).updateContiStatus(anyLong(), any(ContiStatus.class), any(User.class));
     when(contiService.getContiById(anyLong())).thenReturn(updatedConti);
 
     // when & then
@@ -385,7 +385,7 @@ class ContiControllerTest {
     // given
     when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(testUser));
     when(contiService.getContiByIdAndCreator(anyLong(), any(User.class))).thenReturn(testConti);
-    doNothing().when(contiService).deleteConti(anyLong());
+    doNothing().when(contiService).deleteConti(anyLong(), any(User.class));
 
     // when & then
     mockMvc.perform(delete("/conti/{contiId}", 1L))

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/ContiServiceTest.java
@@ -516,7 +516,7 @@ class ContiServiceTest {
     when(contiRepository.save(any(Conti.class))).thenReturn(testConti);
 
     // when
-    contiService.updateContiStatus(1L, ContiStatus.FINALIZED);
+    contiService.updateContiStatus(1L, ContiStatus.FINALIZED, testUser);
 
     // then
     verify(contiRepository).save(any(Conti.class));
@@ -529,7 +529,7 @@ class ContiServiceTest {
     when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
 
     // when
-    contiService.deleteConti(1L);
+    contiService.deleteConti(1L,  testUser);
 
     // then
     verify(contiRepository).delete(testConti);

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareControllerTest.java
@@ -1,0 +1,440 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareRequest;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceAlreadyExistsException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestConfig.class, TestSecurityConfig.class})
+class ContiShareControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ContiShareService contiShareService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  private User testUser;
+  private User targetUser;
+  private Conti testConti;
+  private ContiShare testShare;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("test@example.com")
+        .name("Test User")
+        .role(Role.USER)
+        .build();
+
+    targetUser = User.builder()
+        .id(2L)
+        .email("target@example.com")
+        .name("Target User")
+        .role(Role.USER)
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("Test Conti")
+        .description("Test Description")
+        .scheduledAt(LocalDate.now())
+        .creator(testUser)
+        .status(ContiStatus.DRAFT)
+        .version("1.0")
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    testShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(targetUser)
+        .sharedBy(testUser)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(false)
+        .invitedAt(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 성공")
+  @WithMockUser(username = "test@example.com")
+  void createShareSuccess() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiShareService.createShare(any(ContiShareRequest.class), any(User.class))).thenReturn(
+        testShare);
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.contiId").value(1L))
+        .andExpect(jsonPath("$.contiTitle").value("Test Conti"))
+        .andExpect(jsonPath("$.userEmail").value("target@example.com"))
+        .andExpect(jsonPath("$.permission").value("VIEW"))
+        .andExpect(jsonPath("$.accepted").value(false));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (유효성 검증)")
+  @WithMockUser(username = "test@example.com")
+  void createShareValidationFail() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.message").value("유효성 검증에 실패했습니다."))
+        .andExpect(jsonPath("$.errors.contiId").exists());
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (콘티 없음)")
+  @WithMockUser(username = "test@example.com")
+  void createShareFailNoConti() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(999L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiShareService.createShare(any(ContiShareRequest.class), any(User.class)))
+        .thenThrow(new ResourceNotFoundException("콘티를 찾을 수 없습니다. ID: 999"));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.message").value("콘티를 찾을 수 없습니다. ID: 999"));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (사용자 없음)")
+  @WithMockUser(username = "test@example.com")
+  void createShareFailNoUser() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("nonexistent@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiShareService.createShare(any(ContiShareRequest.class), any(User.class)))
+        .thenThrow(new ResourceNotFoundException("사용자를 찾을 수 없습니다. Email: nonexistent@example.com"));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다. Email: nonexistent@example.com"));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (이미 공유됨)")
+  @WithMockUser(username = "test@example.com")
+  void createShareFailAlreadyShared() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiShareService.createShare(any(ContiShareRequest.class), any(User.class)))
+        .thenThrow(new ResourceAlreadyExistsException("이미 해당 사용자에게 공유된 콘티입니다."));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.status").value(409))
+        .andExpect(jsonPath("$.message").value("이미 해당 사용자에게 공유된 콘티입니다."));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (권한 없음)")
+  @WithMockUser(username = "test@example.com")
+  void createShareFailNoPermission() throws Exception {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiShareService.createShare(any(ContiShareRequest.class), any(User.class)))
+        .thenThrow(new AuthenticationException("콘티를 공유할 권한이 없습니다."));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.message").value("콘티를 공유할 권한이 없습니다."));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 성공")
+  @WithMockUser(username = "test@example.com")
+  void acceptShareSuccess() throws Exception {
+    // given
+    ContiShare acceptedShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(testUser)
+        .sharedBy(targetUser)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDateTime.now())
+        .acceptedAt(LocalDateTime.now())
+        .build();
+
+    when(contiShareService.acceptShare(anyLong(), any(User.class))).thenReturn(acceptedShare);
+
+    // when & then
+    mockMvc.perform(post("/conti/shares/{shareId}/accept", 1L))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.contiId").value(1L))
+        .andExpect(jsonPath("$.accepted").value(true))
+        .andExpect(jsonPath("$.acceptedAt").exists());
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 실패 (공유 정보 없음)")
+  @WithMockUser(username = "test@example.com")
+  void acceptShareFailNoShare() throws Exception {
+    // given
+    when(contiShareService.acceptShare(anyLong(), any(User.class)))
+        .thenThrow(new ResourceNotFoundException("공유 정보를 찾을 수 없습니다. ID: 999"));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares/{shareId}/accept", 999L))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.message").value("공유 정보를 찾을 수 없습니다. ID: 999"));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 실패 (권한 없음)")
+  @WithMockUser(username = "test@example.com")
+  void acceptShareFailNoPermission() throws Exception {
+    // given
+    when(contiShareService.acceptShare(anyLong(), any(User.class)))
+        .thenThrow(new AuthenticationException("해당 공유 요청에 대한 권한이 없습니다."));
+
+    // when & then
+    mockMvc.perform(post("/conti/shares/{shareId}/accept", 1L))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.message").value("해당 공유 요청에 대한 권한이 없습니다."));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 성공")
+  @WithMockUser(username = "test@example.com")
+  void deleteShareSuccess() throws Exception {
+    // given
+    doNothing().when(contiShareService).deleteShare(anyLong(), any(User.class));
+
+    // when & then
+    mockMvc.perform(delete("/conti/shares/{shareId}", 1L))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 실패 (공유 정보 없음)")
+  @WithMockUser(username = "test@example.com")
+  void deleteShareFailNoShare() throws Exception {
+    // given
+    doThrow(new ResourceNotFoundException("공유 정보를 찾을 수 없습니다. ID: 999"))
+        .when(contiShareService).deleteShare(anyLong(), any(User.class));
+
+    // when & then
+    mockMvc.perform(delete("/conti/shares/{shareId}", 999L))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.message").value("공유 정보를 찾을 수 없습니다. ID: 999"));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 권한 수정 - 성공")
+  @WithMockUser(username = "test@example.com")
+  void updatePermissionSuccess() throws Exception {
+    // given
+    ContiShare updatedShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(targetUser)
+        .sharedBy(testUser)
+        .permission(ContiSharePermission.EDIT)
+        .accepted(false)
+        .invitedAt(LocalDateTime.now())
+        .build();
+
+    when(contiShareService.updateSharePermission(anyLong(), any(ContiSharePermission.class),
+        any(User.class))).thenReturn(updatedShare);
+
+    // when & then
+    mockMvc.perform(put("/conti/shares/{shareId}/permission", 1L)
+            .param("permission", "EDIT"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.permission").value("EDIT"));
+  }
+
+  @Test
+  @DisplayName("내게 공유된 콘티 목록 조회")
+  @WithMockUser(username = "test@example.com")
+  void getSharedWithMe() throws Exception {
+    // given
+    ContiShare acceptedShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(testUser)
+        .sharedBy(targetUser)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDateTime.now())
+        .acceptedAt(LocalDateTime.now())
+        .build();
+
+    when(contiShareService.getSharedContis(any(User.class))).thenReturn(
+        Collections.singletonList(acceptedShare));
+
+    // when & then
+    mockMvc.perform(get("/conti/shares/shared-with-me"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].contiId").value(1L))
+        .andExpect(jsonPath("$[0].contiTitle").value("Test Conti"))
+        .andExpect(jsonPath("$[0].accepted").value(true));
+  }
+
+  @Test
+  @DisplayName("내게 온 공유 요청 목록 조회")
+  @WithMockUser(username = "test@example.com")
+  void getPendingShares() throws Exception {
+    // given
+    ContiShare pendingShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(testUser)
+        .sharedBy(targetUser)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(false)
+        .invitedAt(LocalDateTime.now())
+        .build();
+
+    when(contiShareService.getPendingShares(any(User.class))).thenReturn(
+        Collections.singletonList(pendingShare));
+
+    // when & then
+    mockMvc.perform(get("/conti/shares/pending"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].contiId").value(1L))
+        .andExpect(jsonPath("$[0].accepted").value(false));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 목록 조회")
+  @WithMockUser(username = "test@example.com")
+  void getContiShares() throws Exception {
+    // given
+    when(contiShareService.getContiShares(anyLong(), any(User.class))).thenReturn(
+        Collections.singletonList(testShare));
+
+    // when & then
+    mockMvc.perform(get("/conti/shares/conti/{contiId}", 1L))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].userEmail").value("target@example.com"))
+        .andExpect(jsonPath("$[0].permission").value("VIEW"));
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareIntegrationTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareIntegrationTest.java
@@ -1,0 +1,377 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiRepository;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareRequest;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestConfig.class, TestSecurityConfig.class})
+public class ContiShareIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private ContiRepository contiRepository;
+
+  @Autowired
+  private ContiShareRepository contiShareRepository;
+
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
+  private User creator;
+  private User sharedUser;
+  private Conti testConti;
+
+  @BeforeEach
+  @Transactional
+  void setUp() {
+    userRepository.deleteAll();
+    contiRepository.deleteAll();
+    contiShareRepository.deleteAll();
+
+    creator = User.builder()
+        .email("creator@example.com")
+        .password(passwordEncoder.encode("Password123!"))
+        .name("Creator")
+        .role(Role.USER)
+        .isActive(true)
+        .build();
+    creator = userRepository.save(creator);
+
+    sharedUser = User.builder()
+        .email("shared@example.com")
+        .password(passwordEncoder.encode("Password123!"))
+        .name("Shared User")
+        .role(Role.USER)
+        .isActive(true)
+        .build();
+    sharedUser = userRepository.save(sharedUser);
+
+    testConti = Conti.builder()
+        .title("통합 테스트 콘티")
+        .description("콘티 공유 통합 테스트")
+        .scheduledAt(LocalDate.now())
+        .creator(creator)
+        .status(ContiStatus.DRAFT)
+        .version("1.0")
+        .build();
+    testConti = contiRepository.save(testConti);
+  }
+
+  @AfterEach
+  @Transactional
+  void tearDown() {
+    contiShareRepository.deleteAll();
+    contiRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 및 수락 통합 테스트")
+  @WithMockUser(username = "creator@example.com")
+  @Transactional
+  void shareContiAndAcceptIntegrationTest() throws Exception {
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(testConti.getId());
+    request.setUserEmail(sharedUser.getEmail());
+    request.setPermission(ContiSharePermission.EDIT);
+
+    MvcResult createResult = mockMvc.perform(post("/conti/shares")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.contiId").value(testConti.getId()))
+        .andExpect(jsonPath("$.userEmail").value(sharedUser.getEmail()))
+        .andExpect(jsonPath("$.permission").value("EDIT"))
+        .andExpect(jsonPath("$.accepted").value(false))
+        .andReturn();
+
+    String createResponseJson = createResult.getResponse().getContentAsString();
+    Long shareId = objectMapper.readTree(createResponseJson).path("id").asLong();
+
+    Optional<ContiShare> savedShare = contiShareRepository.findById(shareId);
+    assertThat(savedShare).isPresent();
+    assertThat(savedShare.get().getConti().getId()).isEqualTo(testConti.getId());
+    assertThat(savedShare.get().getUser().getId()).isEqualTo(sharedUser.getId());
+    assertThat(savedShare.get().getPermission()).isEqualTo(ContiSharePermission.EDIT);
+    assertThat(savedShare.get().isAccepted()).isFalse();
+
+    mockMvc.perform(post("/conti/shares/{shareId}/accept", shareId)
+            .with(SecurityMockMvcRequestPostProcessors.user("shared@example.com")))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(shareId))
+        .andExpect(jsonPath("$.accepted").value(true))
+        .andExpect(jsonPath("$.acceptedAt").exists());
+
+    Optional<ContiShare> acceptedShare = contiShareRepository.findById(shareId);
+    assertThat(acceptedShare).isPresent();
+    assertThat(acceptedShare.get().isAccepted()).isTrue();
+    assertThat(acceptedShare.get().getAcceptedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("공유된 콘티 목록 조회 통합 테스트")
+  @WithMockUser(username = "shared@example.com")
+  @Transactional
+  void getSharedContisIntegrationTest() throws Exception {
+    ContiShare share = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(share);
+
+    mockMvc.perform(get("/conti/shares/shared-with-me"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].contiId").value(testConti.getId()))
+        .andExpect(jsonPath("$[0].contiTitle").value(testConti.getTitle()))
+        .andExpect(jsonPath("$[0].accepted").value(true));
+  }
+
+  @Test
+  @DisplayName("공유 요청 목록 조회 통합 테스트")
+  @WithMockUser(username = "shared@example.com")
+  @Transactional
+  void getPendingSharesIntegrationTest() throws Exception {
+    ContiShare share = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(false)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(share);
+
+    mockMvc.perform(get("/conti/shares/pending"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].contiId").value(testConti.getId()))
+        .andExpect(jsonPath("$[0].contiTitle").value(testConti.getTitle()))
+        .andExpect(jsonPath("$[0].accepted").value(false));
+  }
+
+  @Test
+  @DisplayName("공유 권한 수정 통합 테스트")
+  @WithMockUser(username = "creator@example.com")
+  @Transactional
+  void updateSharePermissionIntegrationTest() throws Exception {
+    ContiShare share = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    ContiShare savedShare = contiShareRepository.save(share);
+
+    mockMvc.perform(put("/conti/shares/{shareId}/permission", savedShare.getId())
+            .param("permission", "ADMIN"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(savedShare.getId()))
+        .andExpect(jsonPath("$.permission").value("ADMIN"));
+
+    Optional<ContiShare> updatedShare = contiShareRepository.findById(savedShare.getId());
+    assertThat(updatedShare).isPresent();
+    assertThat(updatedShare.get().getPermission()).isEqualTo(ContiSharePermission.ADMIN);
+  }
+
+  @Test
+  @DisplayName("공유 삭제 통합 테스트")
+  @WithMockUser(username = "creator@example.com")
+  @Transactional
+  void deleteShareIntegrationTest() throws Exception {
+    ContiShare share = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    ContiShare savedShare = contiShareRepository.save(share);
+
+    mockMvc.perform(delete("/conti/shares/{shareId}", savedShare.getId()))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+
+    Optional<ContiShare> deletedShare = contiShareRepository.findById(savedShare.getId());
+    assertThat(deletedShare).isEmpty();
+  }
+
+  @Test
+  @DisplayName("콘티 권한에 따른 공유 목록 조회 통합 테스트")
+  @WithMockUser(username = "creator@example.com")
+  @Transactional
+  void getContiSharesIntegrationTest() throws Exception {
+    ContiShare share1 = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(share1);
+
+    User anotherUser = User.builder()
+        .email("another@example.com")
+        .password(passwordEncoder.encode("Password123!"))
+        .name("Another User")
+        .role(Role.USER)
+        .isActive(true)
+        .build();
+    anotherUser = userRepository.save(anotherUser);
+
+    ContiShare share2 = ContiShare.builder()
+        .conti(testConti)
+        .user(anotherUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.EDIT)
+        .accepted(false)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(share2);
+
+    mockMvc.perform(get("/conti/shares/conti/{contiId}", testConti.getId()))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].contiId").value(testConti.getId()))
+        .andExpect(jsonPath("$[1].contiId").value(testConti.getId()))
+        .andExpect(jsonPath("$[?(@.userEmail == \"shared@example.com\")].permission").value("VIEW"))
+        .andExpect(
+            jsonPath("$[?(@.userEmail == \"another@example.com\")].permission").value("EDIT"));
+  }
+
+  @Test
+  @DisplayName("공유된 콘티 접근 권한 통합 테스트")
+  @Transactional
+  void contiAccessPermissionIntegrationTest() throws Exception {
+    ContiShare viewShare = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(viewShare);
+
+    mockMvc.perform(get("/conti/{contiId}", testConti.getId())
+            .with(SecurityMockMvcRequestPostProcessors.user("shared@example.com")))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(testConti.getId()))
+        .andExpect(jsonPath("$.title").value(testConti.getTitle()))
+        .andExpect(jsonPath("$.canEdit").value(false))
+        .andExpect(jsonPath("$.canShare").value(false))
+        .andExpect(jsonPath("$.permissionType").value("VIEW"));
+
+    String updateJson = "{\"title\":\"Updated Title\"}";
+    mockMvc.perform(put("/conti/{contiId}", testConti.getId())
+            .with(SecurityMockMvcRequestPostProcessors.user("shared@example.com"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(updateJson))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("콘티를 수정할 권한이 없습니다."));
+  }
+
+  @Test
+  @DisplayName("편집 권한 공유 통합 테스트")
+  @Transactional
+  void editPermissionIntegrationTest() throws Exception {
+    ContiShare editShare = ContiShare.builder()
+        .conti(testConti)
+        .user(sharedUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.EDIT)
+        .accepted(true)
+        .invitedAt(LocalDate.now().atStartOfDay())
+        .acceptedAt(LocalDate.now().atStartOfDay())
+        .build();
+    contiShareRepository.save(editShare);
+
+    mockMvc.perform(get("/conti/{contiId}", testConti.getId())
+            .with(SecurityMockMvcRequestPostProcessors.user("shared@example.com")))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(testConti.getId()))
+        .andExpect(jsonPath("$.canEdit").value(true))
+        .andExpect(jsonPath("$.canShare").value(false))
+        .andExpect(jsonPath("$.permissionType").value("EDIT"));
+
+    String updateJson = "{\"title\":\"Updated Title\"}";
+    mockMvc.perform(put("/conti/{contiId}", testConti.getId())
+            .with(SecurityMockMvcRequestPostProcessors.user("shared@example.com"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(updateJson))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("Updated Title"));
+
+    Optional<Conti> updatedConti = contiRepository.findById(testConti.getId());
+    assertThat(updatedConti).isPresent();
+    assertThat(updatedConti.get().getTitle()).isEqualTo("Updated Title");
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/share/ContiShareServiceTest.java
@@ -1,0 +1,649 @@
+package faithcoderlab.newdpraise.domain.conti.share;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiRepository;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.share.dto.ContiShareRequest;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceAlreadyExistsException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContiShareServiceTest {
+
+  @Mock
+  private ContiShareRepository contiShareRepository;
+
+  @Mock
+  private ContiRepository contiRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private ContiShareService contiShareService;
+
+  private User creator;
+  private User targetUser;
+  private User adminUser;
+  private Conti testConti;
+  private ContiShare testShare;
+
+  @BeforeEach
+  void setUp() {
+    creator = User.builder()
+        .id(1L)
+        .email("creator@example.com")
+        .name("Creator")
+        .role(Role.USER)
+        .build();
+
+    targetUser = User.builder()
+        .id(2L)
+        .email("target@example.com")
+        .name("Target User")
+        .role(Role.USER)
+        .build();
+
+    adminUser = User.builder()
+        .id(3L)
+        .email("admin@example.com")
+        .role(Role.USER)
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("Test Conti")
+        .description("Test Description")
+        .scheduledAt(LocalDate.now())
+        .creator(creator)
+        .status(ContiStatus.DRAFT)
+        .version("1.0")
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    testShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(targetUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(false)
+        .invitedAt(LocalDateTime.now())
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 성공")
+  void createShareSuccess() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(userRepository.findByEmail("target@example.com")).thenReturn(Optional.of(targetUser));
+    when(contiShareRepository.findByContiAndUser(testConti, targetUser)).thenReturn(
+        Optional.empty());
+    when(contiShareRepository.save(any(ContiShare.class))).thenReturn(testShare);
+
+    // when
+    ContiShare result = contiShareService.createShare(request, creator);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getConti()).isEqualTo(testConti);
+    assertThat(result.getUser()).isEqualTo(targetUser);
+    assertThat(result.getSharedBy()).isEqualTo(creator);
+    assertThat(result.getPermission()).isEqualTo(ContiSharePermission.VIEW);
+    assertThat(result.isAccepted()).isFalse();
+
+    verify(contiRepository).findById(1L);
+    verify(userRepository).findByEmail("target@example.com");
+    verify(contiShareRepository).findByContiAndUser(testConti, targetUser);
+    verify(contiShareRepository).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (콘티 없음)")
+  void createShareFailNoConti() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(999L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.createShare(request, creator))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("콘티를 찾을 수 없습니다");
+
+    verify(contiRepository).findById(999L);
+    verify(userRepository, never()).findByEmail(anyString());
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (사용자 없음)")
+  void createShareFailNoUser() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("nonexistent@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(userRepository.findByEmail("nonexistent@example.com")).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.createShare(request, creator))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("사용자를 찾을 수 없습니다");
+
+    verify(contiRepository).findById(1L);
+    verify(userRepository).findByEmail("nonexistent@example.com");
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (자기 자신에게 공유)")
+  void createShareFailSelfShare() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("creator@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(userRepository.findByEmail("creator@example.com")).thenReturn(Optional.of(creator));
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.createShare(request, creator))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("자신에게는 콘티를 공유할 수 없습니다");
+
+    verify(contiRepository).findById(1L);
+    verify(userRepository).findByEmail("creator@example.com");
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (이미 공유됨)")
+  void createShareFailAlreadyShared() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(userRepository.findByEmail("target@example.com")).thenReturn(Optional.of(targetUser));
+    when(contiShareRepository.findByContiAndUser(testConti, targetUser)).thenReturn(
+        Optional.of(testShare));
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.createShare(request, creator))
+        .isInstanceOf(ResourceAlreadyExistsException.class)
+        .hasMessageContaining("이미 해당 사용자에게 공유된 콘티입니다");
+
+    verify(contiRepository).findById(1L);
+    verify(userRepository).findByEmail("target@example.com");
+    verify(contiShareRepository).findByContiAndUser(testConti, targetUser);
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 생성 - 실패 (권한 없음)")
+  void createShareFailNoPermission() {
+    // given
+    ContiShareRequest request = new ContiShareRequest();
+    request.setContiId(1L);
+    request.setUserEmail("target@example.com");
+    request.setPermission(ContiSharePermission.VIEW);
+
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    Conti conti = Conti.builder()
+        .id(1L)
+        .title("Test Conti")
+        .creator(creator)
+        .build();
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(conti));
+    when(contiShareRepository.hasPermission(1L, 4L,
+        List.of(ContiSharePermission.ADMIN))).thenReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.createShare(request, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("콘티를 공유할 권한이 없습니다");
+
+    verify(contiRepository).findById(1L);
+    verify(contiShareRepository).hasPermission(1L, 4L, List.of(ContiSharePermission.ADMIN));
+    verify(userRepository, never()).findByEmail(anyString());
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 성공")
+  void acceptShareSuccess() {
+    // given
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+    when(contiShareRepository.save(any(ContiShare.class))).thenReturn(testShare);
+
+    // when
+    ContiShare result = contiShareService.acceptShare(1L, targetUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.isAccepted()).isTrue();
+    assertThat(result.getAcceptedAt()).isNotNull();
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository).save(testShare);
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 실패 (공유 정보 없음)")
+  void acceptShareFailNoShare() {
+    // given
+    when(contiShareRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.acceptShare(999L, targetUser))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("공유 정보를 찾을 수 없습니다");
+
+    verify(contiShareRepository).findById(999L);
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 실패 (다른 사용자)")
+  void acceptShareFailWrongUser() {
+    // given
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.acceptShare(1L, creator))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 공유 요청에 대한 권한이 없습니다");
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 초대 수락 - 실패 (이미 수락됨)")
+  void acceptShareFailAlreadyAccepted() {
+    // given
+    ContiShare acceptedShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(targetUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .invitedAt(LocalDateTime.now())
+        .acceptedAt(LocalDateTime.now())
+        .build();
+
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(acceptedShare));
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.acceptShare(1L, targetUser))
+        .isInstanceOf(ResourceAlreadyExistsException.class)
+        .hasMessageContaining("이미 수락된 공유 요청입니다");
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 성공 (공유 받은 사용자)")
+  void deleteShareSuccessAsUser() {
+    // given
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+
+    // when
+    contiShareService.deleteShare(1L, targetUser);
+
+    // then
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository).delete(testShare);
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 성공 (공유한 사용자)")
+  void deleteShareSuccessAsSharer() {
+    // given
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+
+    // when
+    contiShareService.deleteShare(1L, creator);
+
+    // then
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository).delete(testShare);
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 실패 (공유 정보 없음)")
+  void deleteShareFailNoShare() {
+    // given
+    when(contiShareRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.deleteShare(999L, targetUser))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("공유 정보를 찾을 수 없습니다");
+
+    verify(contiShareRepository).findById(999L);
+    verify(contiShareRepository, never()).delete(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 삭제 - 실패 (권한 없음)")
+  void deleteShareFailNoPermission() {
+    // given
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.deleteShare(1L, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 공유 요청을 삭제할 권한이 없습니다");
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository, never()).delete(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 권한 수정 - 성공")
+  void updateSharePermissionSuccess() {
+    // given
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+    when(contiShareRepository.save(any(ContiShare.class))).thenReturn(testShare);
+
+    // when
+    ContiShare result = contiShareService.updateSharePermission(1L, ContiSharePermission.EDIT,
+        creator);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getPermission()).isEqualTo(ContiSharePermission.EDIT);
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository).save(testShare);
+  }
+
+  @Test
+  @DisplayName("콘티 공유 권한 수정 - 실패 (공유 정보 없음)")
+  void updateSharePermissionFailNoShare() {
+    // given
+    when(contiShareRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+        () -> contiShareService.updateSharePermission(999L, ContiSharePermission.EDIT, creator))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("공유 정보를 찾을 수 없습니다");
+
+    verify(contiShareRepository).findById(999L);
+    verify(contiShareRepository, never()).delete(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("콘티 공유 권한 수정 - 실패 (권한 없음)")
+  void updateSharePermissionFailNoPermission() {
+    // given
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    when(contiShareRepository.findById(1L)).thenReturn(Optional.of(testShare));
+
+    // when & then
+    assertThatThrownBy(
+        () -> contiShareService.updateSharePermission(1L, ContiSharePermission.EDIT, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 공유 요청의 권한을 수정할 권한이 없습니다");
+
+    verify(contiShareRepository).findById(1L);
+    verify(contiShareRepository, never()).save(any(ContiShare.class));
+  }
+
+  @Test
+  @DisplayName("사용자에게 공유된 콘티 목록 조회")
+  void getSharedContis() {
+    // given
+    ContiShare acceptedShare = ContiShare.builder()
+        .id(1L)
+        .conti(testConti)
+        .user(targetUser)
+        .sharedBy(creator)
+        .permission(ContiSharePermission.VIEW)
+        .accepted(true)
+        .build();
+
+    when(contiShareRepository.findByUserAndAcceptedTrue(targetUser)).thenReturn(
+        Collections.singletonList(acceptedShare));
+
+    // when
+    List<ContiShare> result = contiShareService.getSharedContis(targetUser);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getConti()).isEqualTo(testConti);
+    assertThat(result.get(0).isAccepted()).isTrue();
+
+    verify(contiShareRepository).findByUserAndAcceptedTrue(targetUser);
+  }
+
+  @Test
+  @DisplayName("사용자가 받은 콘티 공유 요청 목록 조회")
+  void getPendingShares() {
+    // given
+    when(contiShareRepository.findByUserAndAcceptedFalse(targetUser)).thenReturn(
+        Collections.singletonList(testShare));
+
+    // when
+    List<ContiShare> result = contiShareService.getPendingShares(targetUser);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getConti()).isEqualTo(testConti);
+    assertThat(result.get(0).isAccepted()).isFalse();
+
+    verify(contiShareRepository).findByUserAndAcceptedFalse(targetUser);
+  }
+
+  @Test
+  @DisplayName("콘티에 대한 공유 목록 조회 - 성공")
+  void getContiSharesSuccess() {
+    // given
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(contiShareRepository.findByConti(testConti)).thenReturn(
+        Collections.singletonList(testShare));
+
+    // when
+    List<ContiShare> result = contiShareService.getContiShares(1L, creator);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getUser()).isEqualTo(targetUser);
+    assertThat(result.get(0).getPermission()).isEqualTo(ContiSharePermission.VIEW);
+
+    verify(contiRepository).findById(1L);
+    verify(contiShareRepository).findByConti(testConti);
+  }
+
+  @Test
+  @DisplayName("콘티에 대한 공유 목록 조회 - 실패 (콘티 없음)")
+  void getContiSharesFailNoConti() {
+    // given
+    when(contiRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.getContiShares(999L, creator))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("콘티를 찾을 수 없습니다");
+
+    verify(contiRepository).findById(999L);
+    verify(contiShareRepository, never()).findByConti(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("콘티에 대한 공유 목록 조회 - 실패 (권한 없음)")
+  void getContiSharesFailNoPermission() {
+    // given
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(
+        contiShareRepository.hasPermission(1L, 4L, List.of(ContiSharePermission.ADMIN))).thenReturn(
+        false);
+
+    // when & then
+    assertThatThrownBy(() -> contiShareService.getContiShares(1L, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("콘티를 공유할 권한이 없습니다");
+
+    verify(contiRepository).findById(1L);
+    verify(contiShareRepository, never()).findByConti(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("권한 확인 - 콘티 편집 가능")
+  void canEditContiSuccess() {
+    // given & when
+    boolean creatorCanEdit = contiShareService.canEditConti(testConti, creator);
+    // then
+    assertThat(creatorCanEdit).isTrue();
+
+    when(contiShareRepository.hasPermission(1L, 3L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT)))
+        .thenReturn(true);
+    // when
+    boolean adminCanEdit = contiShareService.canEditConti(testConti, adminUser);
+    // then
+    assertThat(adminCanEdit).isTrue();
+    verify(contiShareRepository).hasPermission(1L, 3L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT));
+  }
+
+  @Test
+  @DisplayName("권한 확인 - 콘티 편집 불가")
+  void canEditContiFail() {
+    // given
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    when(contiShareRepository.hasPermission(1L, 4L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT)))
+        .thenReturn(false);
+
+    // when
+    boolean otherCanEdit = contiShareService.canEditConti(testConti, otherUser);
+
+    // then
+    assertThat(otherCanEdit).isFalse();
+    verify(contiShareRepository).hasPermission(1L, 4L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT));
+  }
+
+  @Test
+  @DisplayName("권한 확인 - 콘티 조회 가능")
+  void canViewContiSuccess() {
+    // given & when
+    boolean creatorCanView = contiShareService.canViewConti(testConti, creator);
+    // then
+    assertThat(creatorCanView).isTrue();
+
+    when(contiShareRepository.hasPermission(1L, 2L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT, ContiSharePermission.VIEW)))
+        .thenReturn(true);
+    // when
+    boolean userCanView = contiShareService.canViewConti(testConti, targetUser);
+    // when
+    assertThat(userCanView).isTrue();
+    verify(contiShareRepository).hasPermission(1L, 2L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT, ContiSharePermission.VIEW));
+  }
+
+  @Test
+  @DisplayName("권한 확인 - 콘티 조회 불가")
+  void canViewContiFail() {
+    // given
+    User otherUser = User.builder()
+        .id(4L)
+        .email("other@example.com")
+        .name("Other User")
+        .role(Role.USER)
+        .build();
+
+    when(contiShareRepository.hasPermission(1L, 4L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT, ContiSharePermission.VIEW)))
+        .thenReturn(false);
+
+    // when
+    boolean otherCanView = contiShareService.canViewConti(testConti, otherUser);
+
+    // then
+    assertThat(otherCanView).isFalse();
+    verify(contiShareRepository).hasPermission(1L, 4L,
+        List.of(ContiSharePermission.ADMIN, ContiSharePermission.EDIT, ContiSharePermission.VIEW));
+  }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,5 +1,7 @@
+DROP TABLE IF EXISTS conti_shares;
 DROP TABLE IF EXISTS refresh_tokens;
 DROP TABLE IF EXISTS conti_songs;
+DROP TABLE IF EXISTS songs;
 DROP TABLE IF EXISTS conti;
 DROP TABLE IF EXISTS users;
 
@@ -16,7 +18,45 @@ CREATE TABLE users (
     updated_at TIMESTAMP
 );
 
-DROP TABLE IF EXISTS refresh_tokens;
+CREATE TABLE conti (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    scheduled_at DATE NOT NULL,
+    creator_id BIGINT,
+    version VARCHAR(20) NOT NULL,
+    original_text TEXT,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    FOREIGN KEY (creator_id) REFERENCES users(id)
+);
+
+CREATE TABLE songs (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    original_key VARCHAR(10),
+    performance_key VARCHAR(10),
+    artist VARCHAR(255),
+    youtube_url VARCHAR(255),
+    reference_url VARCHAR(255),
+    url_type VARCHAR(20),
+    duration_seconds INT,
+    special_instructions TEXT,
+    bpm VARCHAR(10),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP
+);
+
+CREATE TABLE conti_songs (
+     conti_id BIGINT NOT NULL,
+     song_id BIGINT NOT NULL,
+     position INT NOT NULL,
+     PRIMARY KEY (conti_id, song_id),
+     FOREIGN KEY (conti_id) REFERENCES conti(id) ON DELETE CASCADE,
+     FOREIGN KEY (song_id) REFERENCES songs(id) ON DELETE CASCADE
+);
+
 CREATE TABLE refresh_tokens (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     token VARCHAR(255) NOT NULL,
@@ -25,16 +65,19 @@ CREATE TABLE refresh_tokens (
     created_at TIMESTAMP NOT NULL
 );
 
-CREATE TABLE conti (
-   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-   title VARCHAR(255),
-   description TEXT,
-   scheduled_at DATE NOT NULL,
-   creator_id BIGINT,
-   version VARCHAR(50) NOT NULL,
-   original_text TEXT,
-   status VARCHAR(20) NOT NULL,
-   created_at TIMESTAMP NOT NULL,
-   updated_at TIMESTAMP,
-   FOREIGN KEY (creator_id) REFERENCES users(id)
+CREATE TABLE conti_shares (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    conti_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    shared_by BIGINT,
+    permission VARCHAR(20) NOT NULL,
+    accepted BOOLEAN NOT NULL DEFAULT FALSE,
+    invited_at TIMESTAMP NOT NULL,
+    accepted_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    FOREIGN KEY (conti_id) REFERENCES conti(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (shared_by) REFERENCES users(id),
+    UNIQUE KEY uk_conti_user (conti_id, user_id)
 );


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 콘티는 생성한 사용자만 접근 가능
- 팀원 간 협업을 위한 공유 기능 없음
- 권한 관리 체계 부재

**TO-BE**
- 콘티를 다른 사용자와 공유할 수 있는 기능 추가
- 세 가지 권한 수준 구현 (VIEW, EDIT, ADMIN)
- 공유 초대, 수락, 거부 플로우 구현
- 공유된 콘티 목록 조회 기능 추가
- 권한에 따른 콘티 접근 통제

### 주요 구현 내용
1. 데이터 모델
  - `ContiShare` 엔티티 및 `ContiSharePermission` 열거형 추가
  - `conti_shares` 테이블 정의 추가
2. 서비스 계층
  - `ContiShareService` 클래스 구현 (공유 생성, 수락, 삭제 등)
  - 권한 관리 및 검증 로직 구현
  - 기존 `ContiService` 확장하여 권한 체크 통합
3. API 테스트
  - `ContiShareController` 구현 (공유 관련 API 엔드포인트)
  - 콘티 API 응답에 권한 정보 포함
4. 테스트 코드
  - 서비스 및 컨트롤러 단위 테스트
  - 통합 테스트 (권한별 접근 검증)

### 테스트
- [x] 서비스 계층 단위 테스트
- [x] 컨트롤러 계층 단위 테스트
- [x] 통합 테스트