### PR TITLE
feat: 콘티 템플릿 기능 구현

### DIFF
--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplate.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplate.java
@@ -1,0 +1,108 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "conti_templates")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiTemplate {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id")
+  private User creator;
+
+  @ManyToMany
+  @JoinTable(
+      name = "conti_template_songs",
+      joinColumns = @JoinColumn(name = "template_id"),
+      inverseJoinColumns = @JoinColumn(name = "song_id")
+  )
+  @OrderColumn(name = "position")
+  private List<Song> songs = new ArrayList<>();
+
+  @Column(nullable = false)
+  private boolean isPublic;
+  @Column(name = "usage_count", nullable = false)
+  private Integer usageCount;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    createdAt = LocalDateTime.now();
+    updatedAt = LocalDateTime.now();
+    if (usageCount == null) {
+      usageCount = 0;
+    }
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    updatedAt = LocalDateTime.now();
+  }
+
+  public Conti toConti(User creator) {
+    Conti conti = Conti.builder()
+        .title(this.name)
+        .description("템플릿에서 생성됨: " + this.name)
+        .creator(creator)
+        .songs(new ArrayList<>(this.songs))
+        .version("1.0")
+        .build();
+
+    this.usageCount++;
+
+    return conti;
+  }
+
+  public static ContiTemplate fromConti(Conti conti, String templateName, boolean isPublic) {
+    return ContiTemplate.builder()
+        .name(templateName)
+        .description("콘티에서 생성됨: " + conti.getTitle())
+        .creator(conti.getCreator())
+        .songs(new ArrayList<>(conti.getSongs()))
+        .isPublic(isPublic)
+        .usageCount(0)
+        .build();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateController.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateController.java
@@ -1,0 +1,347 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.dto.ContiResponse;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateApplyRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateResponse;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateUpdateRequest;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/conti/templates")
+@RequiredArgsConstructor
+@Tag(name = "ContiTemplate", description = "콘티 템플릿 관련 API")
+public class ContiTemplateController {
+
+  private final ContiTemplateService contiTemplateService;
+  private final UserRepository userRepository;
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
+      "yyyy-MM-dd HH:mm:ss");
+
+  @Operation(summary = "템플릿 생성", description = "새로운 콘티 템플릿을 생성합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "템플릿 생성 성공",
+          content = @Content(schema = @Schema(implementation = ContiTemplateResponse.class))),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "404", description = "원본 콘티를 찾을 수 없음")
+  })
+  @PostMapping
+  public ResponseEntity<ContiTemplateResponse> createTemplate(
+      @Valid @RequestBody ContiTemplateCreateRequest request,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    ContiTemplate template = contiTemplateService.createTemplate(request, user);
+
+    ContiTemplateResponse response = mapToTemplateResponse(template, user);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @Operation(summary = "템플릿 조회", description = "특정 콘티 템플릿을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "템플릿 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "템플릿 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "템플릿을 찾을 수 없음")
+  })
+  @GetMapping("/{templateId}")
+  public ResponseEntity<ContiTemplateResponse> getTemplate(
+      @PathVariable Long templateId,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    ContiTemplate template = contiTemplateService.getAccessibleTemplate(templateId, user);
+
+    ContiTemplateResponse response = mapToTemplateResponse(template, user);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "템플릿 수정", description = "기존 콘티 템플릿을 수정합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "템플릿 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "템플릿 수정 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "템플릿을 찾을 수 없음")
+  })
+  @PutMapping("/{templateId}")
+  public ResponseEntity<ContiTemplateResponse> updateTemplate(
+      @PathVariable Long templateId,
+      @Valid @RequestBody ContiTemplateUpdateRequest request,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    ContiTemplate template = contiTemplateService.updateTemplate(templateId, request, user);
+
+    ContiTemplateResponse response = mapToTemplateResponse(template, user);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "템플릿 삭제", description = "콘티 템플릿을 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "템플릿 삭제 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "템플릿 삭제 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "템플릿을 찾을 수 없음")
+  })
+  @DeleteMapping("/{templateId}")
+  public ResponseEntity<Void> deleteTemplate(
+      @PathVariable Long templateId,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    contiTemplateService.deleteTemplate(templateId, user);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "내 템플릿 목록 조회", description = "사용자가 생성한 템플릿 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/my")
+  public ResponseEntity<List<ContiTemplateResponse>> getMyTemplates(Principal principal) {
+    User user = getUserFromPrincipal(principal);
+    List<ContiTemplate> templates = contiTemplateService.getUserTemplates(user);
+
+    List<ContiTemplateResponse> responses = templates.stream()
+        .map(template -> mapToTemplateResponse(template, user))
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "내 템플릿 목록 페이징 조회", description = "사용자가 생성한 템플릿 목록을 페이징하여 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/my/paged")
+  public ResponseEntity<Page<ContiTemplateResponse>> getMyTemplates(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "createdAt") String sort,
+      @RequestParam(defaultValue = "desc") String direction,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+
+    Sort.Direction sortDirection = direction.equalsIgnoreCase("asc") ?
+        Sort.Direction.ASC : Sort.Direction.DESC;
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+    Page<ContiTemplate> templatePage = contiTemplateService.getUserTemplates(user, pageable);
+
+    Page<ContiTemplateResponse> responsePage = templatePage.map(
+        template -> mapToTemplateResponse(template, user)
+    );
+
+    return ResponseEntity.ok(responsePage);
+  }
+
+  @Operation(summary = "공개 템플릿 목록 조회", description = "공개된 템플릿 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/public")
+  public ResponseEntity<List<ContiTemplateResponse>> getPublicTemplates(Principal principal) {
+    User user = getUserFromPrincipal(principal);
+    List<ContiTemplate> templates = contiTemplateService.getPublicTemplates();
+
+    List<ContiTemplateResponse> responses = templates.stream()
+        .map(template -> mapToTemplateResponse(template, user))
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "공개 템플릿 목록 페이징 조회", description = "공개된 템플릿 목록을 페이징하여 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/public/paged")
+  public ResponseEntity<Page<ContiTemplateResponse>> getPublicTemplatesPaged(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "createdAt") String sort,
+      @RequestParam(defaultValue = "desc") String direction,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+
+    Sort.Direction sortDirection = direction.equalsIgnoreCase("asc") ?
+        Sort.Direction.ASC : Sort.Direction.DESC;
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+    Page<ContiTemplate> templatePage = contiTemplateService.getPublicTemplates(pageable);
+
+    Page<ContiTemplateResponse> responsePage = templatePage.map(
+        template -> mapToTemplateResponse(template, user)
+    );
+
+    return ResponseEntity.ok(responsePage);
+  }
+
+  @Operation(summary = "접근 가능한 템플릿 목록 조회", description = "사용자가 접근 가능한 모든 템플릿 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/accessible")
+  public ResponseEntity<List<ContiTemplateResponse>> getAccessibleTemplates(Principal principal) {
+    User user = getUserFromPrincipal(principal);
+    List<ContiTemplate> templates = contiTemplateService.getAccessibleTemplates(user);
+
+    List<ContiTemplateResponse> responses = templates.stream()
+        .map(template -> mapToTemplateResponse(template, user))
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "인기 템플릿 목록 조회", description = "사용 횟수 기준 인기 템플릿 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+  })
+  @GetMapping("/popular")
+  public ResponseEntity<List<ContiTemplateResponse>> getPopularTemplates(
+      @RequestParam(defaultValue = "5") int limit,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    List<ContiTemplate> templates = contiTemplateService.getPopularTemplates(limit);
+
+    List<ContiTemplateResponse> responses = templates.stream()
+        .map(template -> mapToTemplateResponse(template, user))
+        .collect(Collectors.toList());
+
+    return ResponseEntity.ok(responses);
+  }
+
+  @Operation(summary = "템플릿 적용", description = "템플릿을 적용하여 새 콘티를 생성합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "콘티 생성 성공",
+          content = @Content(schema = @Schema(implementation = ContiResponse.class))),
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "템플릿 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "템플릿을 찾을 수 없음")
+  })
+  @PostMapping("/apply")
+  public ResponseEntity<ContiResponse> applyTemplate(
+      @Valid @RequestBody ContiTemplateApplyRequest request,
+      Principal principal
+  ) {
+    User user = getUserFromPrincipal(principal);
+    Conti conti = contiTemplateService.applyTemplate(request.getTemplateId(), user);
+
+    if (request.getCustomTitle() != null && !request.getCustomTitle().isBlank()) {
+      conti.setTitle(request.getCustomTitle());
+    }
+
+    if (request.getCustomDescription() != null && !request.getCustomDescription().isBlank()) {
+      conti.setDescription(request.getCustomDescription());
+    }
+
+    ContiResponse response = mapToContiResponse(conti);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  private User getUserFromPrincipal(Principal principal) {
+    if (principal == null) {
+      throw new AuthenticationException("인증되지 않은 사용자입니다.");
+    }
+
+    return userRepository.findByEmail(principal.getName())
+        .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+  }
+
+  private ContiTemplateResponse mapToTemplateResponse(ContiTemplate template, User currentUser) {
+    boolean isOwner = template.getCreator() != null &&
+        template.getCreator().getId().equals(currentUser.getId());
+
+    return ContiTemplateResponse.builder()
+        .id(template.getId())
+        .name(template.getName())
+        .description(template.getDescription())
+        .creatorId(template.getCreator() != null ? template.getCreator().getId() : null)
+        .creatorName(template.getCreator() != null ? template.getCreator().getName() : null)
+        .isPublic(template.isPublic())
+        .usageCount(template.getUsageCount())
+        .songCount(template.getSongs() != null ? template.getSongs().size() : 0)
+        .createdAt(
+            template.getCreatedAt() != null ? template.getCreatedAt().format(DATE_FORMATTER) : null)
+        .updatedAt(
+            template.getUpdatedAt() != null ? template.getUpdatedAt().format(DATE_FORMATTER) : null)
+        .isOwner(isOwner)
+        .build();
+  }
+
+  private ContiResponse mapToContiResponse(Conti conti) {
+    List<ContiResponse.SongDto> songDtos = new ArrayList<>();
+    if (conti.getSongs() != null) {
+      songDtos = conti.getSongs().stream()
+          .map(song -> ContiResponse.SongDto.builder()
+              .id(song.getId())
+              .title(song.getTitle())
+              .originalKey(song.getOriginalKey())
+              .performanceKey(song.getPerformanceKey())
+              .artist(song.getArtist())
+              .youtubeUrl(song.getYoutubeUrl())
+              .specialInstructions(song.getSpecialInstructions())
+              .build())
+          .collect(Collectors.toList());
+    }
+
+    return ContiResponse.builder()
+        .id(conti.getId())
+        .title(conti.getTitle())
+        .description(conti.getDescription())
+        .scheduledAt(conti.getScheduledAt())
+        .creatorId(conti.getCreator() != null ? conti.getCreator().getId() : null)
+        .creatorName(conti.getCreator() != null ? conti.getCreator().getName() : null)
+        .songs(songDtos)
+        .status(conti.getStatus().name())
+        .createdAt(conti.getCreatedAt())
+        .updatedAt(conti.getUpdatedAt())
+        .canEdit(true)
+        .build();
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateRepository.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateRepository.java
@@ -1,0 +1,33 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import faithcoderlab.newdpraise.domain.user.User;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContiTemplateRepository extends JpaRepository<ContiTemplate, Long> {
+
+  List<ContiTemplate> findByCreator(User creator);
+
+  Page<ContiTemplate> findByCreator(User creator, Pageable pageable);
+
+  List<ContiTemplate> findByIsPublicTrue();
+
+  Page<ContiTemplate> findByIsPublicTrue(Pageable pageable);
+
+  List<ContiTemplate> findByNameContainingIgnoreCase(String name);
+
+  @Query("SELECT t FROM ContiTemplate t WHERE t.creator.id = :userId OR t.isPublic = true")
+  List<ContiTemplate> findAccessibleTemplates(@Param("userId") Long userId);
+
+  @Query("SELECT t FROM ContiTemplate t WHERE t.creator.id = :userId OR t.isPublic = true")
+  Page<ContiTemplate> findAccessibleTemplates(@Param("userId") Long userId, Pageable pageable);
+
+  @Query("SELECT t FROM ContiTemplate t WHERE t.isPublic = true ORDER BY t.usageCount DESC")
+  List<ContiTemplate> findPopularTemplates(Pageable pageable);
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateService.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateService.java
@@ -1,0 +1,146 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiRepository;
+import faithcoderlab.newdpraise.domain.conti.ContiService;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateUpdateRequest;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContiTemplateService {
+
+  private final ContiTemplateRepository contiTemplateRepository;
+  private final ContiRepository contiRepository;
+  private final ContiService contiService;
+
+  @Transactional
+  public ContiTemplate createTemplate(ContiTemplateCreateRequest request, User creator) {
+    if (request.getContiId() != null) {
+      Conti conti = contiRepository.findById(request.getContiId())
+          .orElseThrow(() -> new ResourceNotFoundException("콘티를 찾을 수 없습니다. ID: " + request.getContiId()));
+
+      if (!conti.getCreator().equals(creator)) {
+        throw new AuthenticationException("해당 콘티로부터 템플릿을 생성할 권한이 없습니다.");
+      }
+
+      ContiTemplate template = ContiTemplate.fromConti(conti, request.getName(),
+          request.isPublic());
+      template.setDescription(request.getDescription());
+
+      return contiTemplateRepository.save(template);
+    }
+    else {
+      ContiTemplate template = ContiTemplate.builder()
+          .name(request.getName())
+          .description(request.getDescription())
+          .creator(creator)
+          .isPublic(request.isPublic())
+          .usageCount(0)
+          .build();
+
+      return contiTemplateRepository.save(template);
+    }
+  }
+
+  public ContiTemplate getTemplate(Long templateId) {
+    return contiTemplateRepository.findById(templateId)
+        .orElseThrow(() -> new ResourceNotFoundException("템플릿을 찾을 수 없습니다. ID: " + templateId));
+  }
+
+  public ContiTemplate getAccessibleTemplate(Long templateId, User user) {
+    ContiTemplate template = getTemplate(templateId);
+
+    if (!template.isPublic() && !template.getCreator().getId().equals(user.getId())) {
+      throw new AuthenticationException("해당 템플릿에 접근할 권한이 없습니다.");
+    }
+
+    return template;
+  }
+
+  @Transactional
+  public ContiTemplate updateTemplate(Long templateId, ContiTemplateUpdateRequest request,
+      User user) {
+    ContiTemplate template = getTemplate(templateId);
+
+    if (!template.getCreator().getId().equals(user.getId())) {
+      throw new AuthenticationException("해당 템플릿을 수정할 권한이 없습니다.");
+    }
+
+    if (request.getName() != null) {
+      template.setName(request.getName());
+    }
+
+    if (request.getDescription() != null) {
+      template.setDescription(request.getDescription());
+    }
+
+    if (request.getIsPublic() != null) {
+      template.setPublic(request.getIsPublic());
+    }
+
+    return contiTemplateRepository.save(template);
+  }
+
+  @Transactional
+  public void deleteTemplate(Long templateId, User user) {
+    ContiTemplate template = getTemplate(templateId);
+
+    if (!template.getCreator().getId().equals(user.getId())) {
+      throw new AuthenticationException("해당 템플릿을 삭제할 권한이 없습니다.");
+    }
+
+    contiTemplateRepository.delete(template);
+  }
+
+  public List<ContiTemplate> getUserTemplates(User user) {
+    return contiTemplateRepository.findByCreator(user);
+  }
+
+  public Page<ContiTemplate> getUserTemplates(User user, Pageable pageable) {
+    return contiTemplateRepository.findByCreator(user, pageable);
+  }
+
+  public List<ContiTemplate> getPublicTemplates() {
+    return contiTemplateRepository.findByIsPublicTrue();
+  }
+
+  public Page<ContiTemplate> getPublicTemplates(Pageable pageable) {
+    return contiTemplateRepository.findByIsPublicTrue(pageable);
+  }
+
+  public List<ContiTemplate> getAccessibleTemplates(User user) {
+    return contiTemplateRepository.findAccessibleTemplates(user.getId());
+  }
+
+  public Page<ContiTemplate> getAccessibleTemplates(User user, Pageable pageable) {
+    return contiTemplateRepository.findAccessibleTemplates(user.getId(), pageable);
+  }
+
+  public List<ContiTemplate> getPopularTemplates(int limit) {
+    return contiTemplateRepository.findPopularTemplates(Pageable.ofSize(limit));
+  }
+
+  @Transactional
+  public Conti applyTemplate(Long templateId, User user) {
+    ContiTemplate template = getAccessibleTemplate(templateId, user);
+
+    Conti conti = template.toConti(user);
+    conti.setStatus(ContiStatus.DRAFT);
+
+    contiTemplateRepository.save(template);
+
+    return contiRepository.save(conti);
+  }
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateApplyRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateApplyRequest.java
@@ -1,0 +1,19 @@
+package faithcoderlab.newdpraise.domain.conti.template.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiTemplateApplyRequest {
+
+  private Long templateId;
+
+  private String customTitle;
+
+  private String customDescription;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateCreateRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateCreateRequest.java
@@ -1,0 +1,23 @@
+package faithcoderlab.newdpraise.domain.conti.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiTemplateCreateRequest {
+
+  @NotBlank(message = "템플릿 이름은 필수 입력 항목입니다.")
+  private String name;
+
+  private String description;
+
+  private Long contiId;
+
+  private boolean isPublic;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateResponse.java
@@ -1,0 +1,35 @@
+package faithcoderlab.newdpraise.domain.conti.template.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiTemplateResponse {
+
+  private Long id;
+
+  private String name;
+
+  private String description;
+
+  private Long creatorId;
+
+  private String creatorName;
+
+  private boolean isPublic;
+
+  private Integer usageCount;
+
+  private int songCount;
+
+  private String createdAt;
+
+  private String updatedAt;
+
+  private boolean isOwner;
+}

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateResponse.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateResponse.java
@@ -1,5 +1,6 @@
 package faithcoderlab.newdpraise.domain.conti.template.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +22,7 @@ public class ContiTemplateResponse {
 
   private String creatorName;
 
+  @JsonProperty("isPublic")
   private boolean isPublic;
 
   private Integer usageCount;

--- a/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateUpdateRequest.java
+++ b/src/main/java/faithcoderlab/newdpraise/domain/conti/template/dto/ContiTemplateUpdateRequest.java
@@ -1,0 +1,19 @@
+package faithcoderlab.newdpraise.domain.conti.template.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContiTemplateUpdateRequest {
+
+  private String name;
+
+  private String description;
+
+  private Boolean isPublic;
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateControllerTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateControllerTest.java
@@ -1,0 +1,314 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faithcoderlab.newdpraise.config.TestConfig;
+import faithcoderlab.newdpraise.config.TestSecurityConfig;
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateApplyRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateUpdateRequest;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.domain.user.UserRepository;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestConfig.class, TestSecurityConfig.class})
+class ContiTemplateControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ContiTemplateService contiTemplateService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  private User testUser;
+  private ContiTemplate testTemplate;
+  private Conti testConti;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .build();
+
+    Song testSong = Song.builder()
+        .id(1L)
+        .title("테스트 곡")
+        .originalKey("C")
+        .performanceKey("D")
+        .artist("테스트 아티스트")
+        .build();
+
+    testTemplate = ContiTemplate.builder()
+        .id(1L)
+        .name("테스트 템플릿")
+        .description("테스트 템플릿 설명")
+        .creator(testUser)
+        .songs(new ArrayList<>(Collections.singletonList(testSong)))
+        .isPublic(true)
+        .usageCount(5)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("테스트 콘티")
+        .description("테스트 설명")
+        .scheduledAt(LocalDate.now())
+        .creator(testUser)
+        .songs(new ArrayList<>(Collections.singletonList(testSong)))
+        .version("1.0")
+        .status(ContiStatus.DRAFT)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    when(userRepository.findByEmail("suming@example.com")).thenReturn(Optional.of(testUser));
+  }
+
+  @Test
+  @DisplayName("템플릿 생성 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void createTemplate_Success() throws Exception {
+    // given
+    ContiTemplateCreateRequest request = ContiTemplateCreateRequest.builder()
+        .name("새 템플릿")
+        .description("테스트 용 템플릿")
+        .contiId(1L)
+        .isPublic(true)
+        .build();
+
+    when(
+        contiTemplateService.createTemplate(any(ContiTemplateCreateRequest.class), any(User.class)))
+        .thenReturn(testTemplate);
+
+    // when & then
+    mockMvc.perform(post("/conti/templates")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.name").value("테스트 템플릿"))
+        .andExpect(jsonPath("$.isPublic").value(true))
+        .andExpect(jsonPath("$.usageCount").value(5));
+  }
+
+  @Test
+  @DisplayName("템플릿 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getTemplate_Success() throws Exception {
+    // given
+    when(contiTemplateService.getAccessibleTemplate(anyLong(), any(User.class)))
+        .thenReturn(testTemplate);
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/{templateId}", 1L))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.name").value("테스트 템플릿"))
+        .andExpect(jsonPath("$.isPublic").value(true))
+        .andExpect(jsonPath("$.usageCount").value(5));
+  }
+
+  @Test
+  @DisplayName("템플릿 조회 - 실패 (권한 없음)")
+  @WithMockUser(username = "suming@example.com")
+  void getTemplate_Unauthorized() throws Exception {
+    // given
+    when(contiTemplateService.getAccessibleTemplate(anyLong(), any(User.class)))
+        .thenThrow(new AuthenticationException("해당 템플릿에 접근할 권한이 없습니다."));
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/{templateId}", 1L))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.message").value("해당 템플릿에 접근할 권한이 없습니다."));
+  }
+
+  @Test
+  @DisplayName("템플릿 수정 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void updateTemplate_Success() throws Exception {
+    // given
+    ContiTemplateUpdateRequest request = ContiTemplateUpdateRequest.builder()
+        .name("수정된 템플릿")
+        .description("수정된 설명")
+        .isPublic(false)
+        .build();
+
+    when(contiTemplateService.updateTemplate(anyLong(), any(ContiTemplateUpdateRequest.class),
+        any(User.class)))
+        .thenReturn(testTemplate);
+
+    // when & then
+    mockMvc.perform(put("/conti/templates/{templateId}", 1L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.name").value("테스트 템플릿"));
+  }
+
+  @Test
+  @DisplayName("템플릿 삭제 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void deleteTemplate_Success() throws Exception {
+    // given
+    doNothing().when(contiTemplateService).deleteTemplate(anyLong(), any(User.class));
+
+    // when & then
+    mockMvc.perform(delete("/conti/templates/{templateId}", 1L))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("내 템플릿 목록 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getMyTemplates_Success() throws Exception {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateService.getUserTemplates(any(User.class))).thenReturn(templates);
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/my"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].name").value("테스트 템플릿"));
+  }
+
+  @Test
+  @DisplayName("공개 템플릿 목록 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getPublicTemplates_Success() throws Exception {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateService.getPublicTemplates()).thenReturn(templates);
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/public"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].name").value("테스트 템플릿"))
+        .andExpect(jsonPath("$[0].isPublic").value(true));
+  }
+
+  @Test
+  @DisplayName("접근 가능한 템플릿 목록 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getAccessibleTemplates_Success() throws Exception {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateService.getAccessibleTemplates(any(User.class))).thenReturn(templates);
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/accessible"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].name").value("테스트 템플릿"));
+  }
+
+  @Test
+  @DisplayName("인기 템플릿 목록 조회 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void getPopularTemplates_Success() throws Exception {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateService.getPopularTemplates(5)).thenReturn(templates);
+
+    // when & then
+    mockMvc.perform(get("/conti/templates/popular")
+            .param("limit", "5"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1L))
+        .andExpect(jsonPath("$[0].name").value("테스트 템플릿"))
+        .andExpect(jsonPath("$[0].usageCount").value(5));
+  }
+
+  @Test
+  @DisplayName("템플릿 적용 - 성공")
+  @WithMockUser(username = "suming@example.com")
+  void applyTemplate_Success() throws Exception {
+    // given
+    ContiTemplateApplyRequest request = ContiTemplateApplyRequest.builder()
+        .templateId(1L)
+        .customTitle("커스텀 제목")
+        .customDescription("커스텀 설명")
+        .build();
+
+    when(contiTemplateService.applyTemplate(anyLong(), any(User.class))).thenReturn(testConti);
+
+    // when & then
+    mockMvc.perform(post("/conti/templates/apply")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.title").value("커스텀 제목"))
+        .andExpect(jsonPath("$.status").value("DRAFT"));
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자 - 실패")
+  void unauthorized_Fail() throws Exception {
+    // when & then
+    mockMvc.perform(get("/conti/templates/my"))
+        .andDo(print())
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateServiceTest.java
+++ b/src/test/java/faithcoderlab/newdpraise/domain/conti/template/ContiTemplateServiceTest.java
@@ -1,0 +1,499 @@
+package faithcoderlab.newdpraise.domain.conti.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import faithcoderlab.newdpraise.domain.conti.Conti;
+import faithcoderlab.newdpraise.domain.conti.ContiRepository;
+import faithcoderlab.newdpraise.domain.conti.ContiService;
+import faithcoderlab.newdpraise.domain.conti.ContiStatus;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateCreateRequest;
+import faithcoderlab.newdpraise.domain.conti.template.dto.ContiTemplateUpdateRequest;
+import faithcoderlab.newdpraise.domain.song.Song;
+import faithcoderlab.newdpraise.domain.user.Role;
+import faithcoderlab.newdpraise.domain.user.User;
+import faithcoderlab.newdpraise.global.exception.AuthenticationException;
+import faithcoderlab.newdpraise.global.exception.ResourceNotFoundException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class ContiTemplateServiceTest {
+
+  @Mock
+  private ContiTemplateRepository contiTemplateRepository;
+
+  @Mock
+  private ContiRepository contiRepository;
+
+  @Mock
+  private ContiService contiService;
+
+  @InjectMocks
+  private ContiTemplateService contiTemplateService;
+
+  private User testUser;
+  private User otherUser;
+  private Conti testConti;
+  private ContiTemplate testTemplate;
+  private Song testSong;
+
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1L)
+        .email("suming@example.com")
+        .name("수밍")
+        .role(Role.USER)
+        .build();
+
+    otherUser = User.builder()
+        .id(2L)
+        .email("other@example.com")
+        .name("수밍 아님")
+        .role(Role.USER)
+        .build();
+
+    testSong = Song.builder()
+        .id(1L)
+        .title("테스트 곡")
+        .originalKey("C")
+        .performanceKey("D")
+        .artist("테스트 아티스트")
+        .build();
+
+    testConti = Conti.builder()
+        .id(1L)
+        .title("테스트 콘티")
+        .description("테스트 설명")
+        .scheduledAt(LocalDate.now())
+        .creator(testUser)
+        .songs(new ArrayList<>(Collections.singletonList(testSong)))
+        .version("1.0")
+        .status(ContiStatus.DRAFT)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    testTemplate = ContiTemplate.builder()
+        .id(1L)
+        .name("테스트 템플릿")
+        .description("테스트 템플릿 설명")
+        .creator(testUser)
+        .songs(new ArrayList<>(Collections.singletonList(testSong)))
+        .isPublic(true)
+        .usageCount(5)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("콘티로부터 템플릿 생성 - 성공")
+  void createTemplateFromConti_Success() {
+    // given
+    ContiTemplateCreateRequest request = ContiTemplateCreateRequest.builder()
+        .name("새 템플릿")
+        .description("테스트 용 템플릿")
+        .contiId(1L)
+        .isPublic(true)
+        .build();
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(testConti));
+    when(contiTemplateRepository.save(any(ContiTemplate.class))).thenReturn(testTemplate);
+
+    // when
+    ContiTemplate result = contiTemplateService.createTemplate(request, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+    assertThat(result.getName()).isEqualTo("테스트 템플릿");
+
+    verify(contiRepository).findById(1L);
+    verify(contiTemplateRepository).save(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("직접 템플릿 생성 - 성공")
+  void createTemplateDirectly_Success() {
+    // given
+    ContiTemplateCreateRequest request = ContiTemplateCreateRequest.builder()
+        .name("새 템플릿")
+        .description("테스트 용 템플릿")
+        .isPublic(true)
+        .build();
+
+    when(contiTemplateRepository.save(any(ContiTemplate.class))).thenReturn(testTemplate);
+
+    // when
+    ContiTemplate result = contiTemplateService.createTemplate(request, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+
+    verify(contiRepository, never()).findById(anyLong());
+    verify(contiTemplateRepository).save(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("콘티로부터 템플릿 생성 - 실패 (콘티 없음)")
+  void createTemplateFromConti_NotFound() {
+    // given
+    ContiTemplateCreateRequest request = ContiTemplateCreateRequest.builder()
+        .name("새 템플릿")
+        .description("테스트 용 템플릿")
+        .contiId(99L)
+        .isPublic(true)
+        .build();
+
+    when(contiRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.createTemplate(request, testUser))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("콘티를 찾을 수 없습니다");
+
+    verify(contiRepository).findById(99L);
+    verify(contiTemplateRepository, never()).save(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("콘티로부터 템플릿 생성 - 실패 (권한 없음)")
+  void createTemplateFromConti_Unauthorized() {
+    // given
+    ContiTemplateCreateRequest request = ContiTemplateCreateRequest.builder()
+        .name("새 템플릿")
+        .description("테스트 용 템플릿")
+        .contiId(1L)
+        .isPublic(true)
+        .build();
+
+    Conti otherUserConti = Conti.builder()
+        .id(1L)
+        .title("다른 사용자의 콘티")
+        .creator(otherUser)
+        .build();
+
+    when(contiRepository.findById(1L)).thenReturn(Optional.of(otherUserConti));
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.createTemplate(request, testUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("템플릿을 생성할 권한이 없습니다");
+
+    verify(contiRepository).findById(1L);
+    verify(contiTemplateRepository, never()).save(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("템플릿 조회 - 성공")
+  void getTemplate_Success() {
+    // given
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+
+    // when
+    ContiTemplate result = contiTemplateService.getTemplate(1L);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+    assertThat(result.getName()).isEqualTo("테스트 템플릿");
+
+    verify(contiTemplateRepository).findById(1L);
+  }
+
+  @Test
+  @DisplayName("템플릿 조회 - 실패 (템플릿 없음)")
+  void getTemplate_NotFound() {
+    // given
+    when(contiTemplateRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.getTemplate(99L))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessageContaining("템플릿을 찾을 수 없습니다");
+
+    verify(contiTemplateRepository).findById(99L);
+  }
+
+  @Test
+  @DisplayName("접근 가능한 템플릿 조회 - 공개 템플릿 성공")
+  void getAccessibleTemplate_PublicSuccess() {
+    // given
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+
+    // when
+    ContiTemplate result = contiTemplateService.getAccessibleTemplate(1L, otherUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findById(1L);
+  }
+
+  @Test
+  @DisplayName("접근 가능한 템플릿 조회 - 본인 비공개 템플릿 성공")
+  void getAccessibleTemplate_OwnerSuccess() {
+    // given
+    ContiTemplate privateTemplate = ContiTemplate.builder()
+        .id(1L)
+        .name("비공개 템플릿")
+        .creator(testUser)
+        .isPublic(false)
+        .build();
+
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(privateTemplate));
+
+    // when
+    ContiTemplate result = contiTemplateService.getAccessibleTemplate(1L, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+    assertThat(result.isPublic()).isFalse();
+
+    verify(contiTemplateRepository).findById(1L);
+  }
+
+  @Test
+  @DisplayName("접근 가능한 템플릿 조회 - 실패 (권한 없음)")
+  void getAccessibleTemplate_Unauthorized() {
+    // given
+    ContiTemplate privateTemplate = ContiTemplate.builder()
+        .id(1L)
+        .name("비공개 템플릿")
+        .creator(testUser)
+        .isPublic(false)
+        .build();
+
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(privateTemplate));
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.getAccessibleTemplate(1L, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 템플릿에 접근할 권한이 없습니다");
+
+    verify(contiTemplateRepository).findById(1L);
+  }
+
+  @Test
+  @DisplayName("템플릿 수정 - 성공")
+  void updateTemplate_Success() {
+    // given
+    ContiTemplateUpdateRequest request = ContiTemplateUpdateRequest.builder()
+        .name("수정된 템플릿")
+        .description("수정된 설명")
+        .isPublic(false)
+        .build();
+
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+    when(contiTemplateRepository.save(any(ContiTemplate.class))).thenReturn(testTemplate);
+
+    // when
+    ContiTemplate result = contiTemplateService.updateTemplate(1L, request, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiTemplateRepository).save(testTemplate);
+  }
+
+  @Test
+  @DisplayName("템플릿 수정 - 실패 (권한 없음)")
+  void updateTemplate_Unauthorized() {
+    // given
+    ContiTemplateUpdateRequest request = ContiTemplateUpdateRequest.builder()
+        .name("수정된 템플릿")
+        .build();
+
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.updateTemplate(1L, request, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 템플릿을 수정할 권한이 없습니다");
+
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiTemplateRepository, never()).save(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("템플릿 삭제 - 성공")
+  void deleteTemplate_Success() {
+    // given
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+
+    // when
+    contiTemplateService.deleteTemplate(1L, testUser);
+
+    // then
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiTemplateRepository).delete(testTemplate);
+  }
+
+  @Test
+  @DisplayName("템플릿 삭제 - 실패 (권한 없음)")
+  void deleteTemplate_Unauthorized() {
+    // given
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.deleteTemplate(1L, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 템플릿을 삭제할 권한이 없습니다");
+
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiTemplateRepository, never()).delete(any(ContiTemplate.class));
+  }
+
+  @Test
+  @DisplayName("사용자 템플릿 목록 조회 - 성공")
+  void getUserTemplates_Success() {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateRepository.findByCreator(testUser)).thenReturn(templates);
+
+    // when
+    List<ContiTemplate> result = contiTemplateService.getUserTemplates(testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.get(0).getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findByCreator(testUser);
+  }
+
+  @Test
+  @DisplayName("사용자 템플릿 목록 페이징 조회 - 성공")
+  void getUserTemplatesPaged_Success() {
+    // given
+    Page<ContiTemplate> templatePage = new PageImpl<>(Collections.singletonList(testTemplate));
+    when(contiTemplateRepository.findByCreator(any(User.class), any(Pageable.class))).thenReturn(
+        templatePage);
+
+    // when
+    Page<ContiTemplate> results = contiTemplateService.getUserTemplates(testUser, Pageable.unpaged());
+
+    // then
+    assertThat(results.getTotalElements()).isEqualTo(1);
+    assertThat(results.getContent().get(0).getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findByCreator(any(User.class), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("공개 템플릿 목록 조회 - 성공")
+  void getPublicTemplates_Success() {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateRepository.findByIsPublicTrue()).thenReturn(templates);
+
+    // when
+    List<ContiTemplate> results = contiTemplateService.getPublicTemplates();
+
+    // then
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findByIsPublicTrue();
+  }
+
+  @Test
+  @DisplayName("접근 가능한 템플릿 목록 조회 - 성공")
+  void getAccessibleTemplates_Success() {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateRepository.findAccessibleTemplates(testUser.getId())).thenReturn(templates);
+
+    // when
+    List<ContiTemplate> results = contiTemplateService.getAccessibleTemplates(testUser);
+
+    // then
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findAccessibleTemplates(testUser.getId());
+  }
+
+  @Test
+  @DisplayName("인기 템플릿 목록 조회 - 성공")
+  void getPopularTemplates_Success() {
+    // given
+    List<ContiTemplate> templates = Collections.singletonList(testTemplate);
+    when(contiTemplateRepository.findPopularTemplates(any(Pageable.class))).thenReturn(templates);
+
+    // when
+    List<ContiTemplate> results = contiTemplateService.getPopularTemplates(5);
+
+    // then
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findPopularTemplates(any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("템플릿 적용 - 성공")
+  void applyTemplate_Success() {
+    // given
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(testTemplate));
+    when(contiRepository.save(any(Conti.class))).thenReturn(testConti);
+
+    // when
+    Conti result = contiTemplateService.applyTemplate(1L, testUser);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(1L);
+
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiTemplateRepository).save(testTemplate);
+    verify(contiRepository).save(any(Conti.class));
+  }
+
+  @Test
+  @DisplayName("템플릿 적용 - 실패 (권한 없음)")
+  void applyTemplate_Unauthorized() {
+    // given
+    ContiTemplate privateTemplate = ContiTemplate.builder()
+        .id(1L)
+        .name("비공개 템플릿")
+        .creator(testUser)
+        .isPublic(false)
+        .build();
+
+    when(contiTemplateRepository.findById(1L)).thenReturn(Optional.of(privateTemplate));
+
+    // when & then
+    assertThatThrownBy(() -> contiTemplateService.applyTemplate(1L, otherUser))
+        .isInstanceOf(AuthenticationException.class)
+        .hasMessageContaining("해당 템플릿에 접근할 권한이 없습니다");
+
+    verify(contiTemplateRepository).findById(1L);
+    verify(contiRepository, never()).save(any(Conti.class));
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 콘티 재사용을 위한 템플릿 기능이 없었음
- 동일한 구성의 콘티를 만들 때마다 처음부터 새로 작성해야 함

**TO-BE**
- 자주 사용하는 콘티 구성을 템플릿으로 저장하고 재사용할 수 있음
- 기존 콘티를 템플릿으로 변환할 수 있음
- 공개/비공개 템플릿을 관리할 수 있음
- 인기 템플릿을 조회하여 활용할 수 있음

### 주요 구현 내용
1. 콘티 템플릿 엔티티 및 리포지토리 구현
  - `ContiTemplate` 엔티티 클래스
  - `ContiTemplateRepository` 인터페이스

2. 템플릿 서비스 계층 구현
  - 템플릿 CRUD 기능 구현
  - 템플릿 권한 관리 로직
  - 템플릿 적용 및 재사용 기능

3. REST API 구현
  - `/api/conti/templates/*` 엔드포인트
  - 사용자별/공개 템플릿 조회 API
  - 인기 템플릿 조회 API

4. 테스트 코드 작성
  - 서비스 단위 테스트
  - 컨트롤러 테스트

### 테스트
- [x] 서비스 단위 테스트
- [x] 컨트롤러 단위 테스트
- [x] API 테스트 